### PR TITLE
Avoid git in directory search

### DIFF
--- a/src/DotNetCensus.Core/Projects/DirectoryScanning.cs
+++ b/src/DotNetCensus.Core/Projects/DirectoryScanning.cs
@@ -54,6 +54,11 @@ namespace DotNetCensus.Core.Projects
                 }
                 foreach (DirectoryInfo subDirectory in new DirectoryInfo(directory).GetDirectories())
                 {
+                    // don't drill into git directory
+                    if (subDirectory.Name == ".git") {
+                        continue;
+                    }
+
                     //Prevent blocking when debugging in Visual Studio.
                     if (subDirectory.Name != ".vs")
                     {


### PR DESCRIPTION
Unpacking large objects in git was creating a memory exception:

![Exception](https://user-images.githubusercontent.com/4307307/232548212-1734ec5b-8fc9-4bba-b6a2-f43642eedeec.png)

There's probably little nutritional value inside of git in terms of dotnet project versions, so can avoid traversing altogether

