### PR TITLE
.NET Framework 4.5.1 is unknown instead of unsupported bug

### DIFF
--- a/samples/Sample.NetFramework451.WebApp/.nuget/NuGet.Config
+++ b/samples/Sample.NetFramework451.WebApp/.nuget/NuGet.Config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <solution>
+    <add key="disableSourceControlIntegration" value="true" />
+  </solution>
+</configuration>

--- a/samples/Sample.NetFramework451.WebApp/.nuget/NuGet.targets
+++ b/samples/Sample.NetFramework451.WebApp/.nuget/NuGet.targets
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildProjectDirectory)\..\</SolutionDir>
+        
+        <!-- Enable the restore command to run before builds -->
+        <RestorePackages Condition="  '$(RestorePackages)' == '' ">false</RestorePackages>
+
+        <!-- Property that enables building a package from a project -->
+        <BuildPackage Condition=" '$(BuildPackage)' == '' ">false</BuildPackage>
+
+        <!-- Determines if package restore consent is required to restore packages -->
+        <RequireRestoreConsent Condition=" '$(RequireRestoreConsent)' != 'false' ">true</RequireRestoreConsent>
+        
+        <!-- Download NuGet.exe if it does not already exist -->
+        <DownloadNuGetExe Condition=" '$(DownloadNuGetExe)' == '' ">true</DownloadNuGetExe>
+    </PropertyGroup>
+    
+    <ItemGroup Condition=" '$(PackageSources)' == '' ">
+        <!-- Package sources used to restore packages. By default will used the registered sources under %APPDATA%\NuGet\NuGet.Config -->
+        <!--
+            <PackageSource Include="https://nuget.org/api/v2/" />
+            <PackageSource Include="https://my-nuget-source/nuget/" />
+        -->
+    </ItemGroup>
+
+    <PropertyGroup Condition=" '$(OS)' == 'Windows_NT'">
+        <!-- Windows specific commands -->
+        <NuGetToolsPath>$([System.IO.Path]::Combine($(SolutionDir), ".nuget"))</NuGetToolsPath>
+        <PackagesConfig>$([System.IO.Path]::Combine($(ProjectDir), "packages.config"))</PackagesConfig>
+        <PackagesDir>$([System.IO.Path]::Combine($(SolutionDir), "packages"))</PackagesDir>
+    </PropertyGroup>
+    
+    <PropertyGroup Condition=" '$(OS)' != 'Windows_NT'">
+        <!-- We need to launch nuget.exe with the mono command if we're not on windows -->
+        <NuGetToolsPath>$(SolutionDir).nuget</NuGetToolsPath>
+        <PackagesConfig>packages.config</PackagesConfig>
+        <PackagesDir>$(SolutionDir)packages</PackagesDir>
+    </PropertyGroup>
+    
+    <PropertyGroup>
+        <!-- NuGet command -->
+        <NuGetExePath Condition=" '$(NuGetExePath)' == '' ">$(NuGetToolsPath)\nuget.exe</NuGetExePath>
+        <PackageSources Condition=" $(PackageSources) == '' ">@(PackageSource)</PackageSources>
+        
+        <NuGetCommand Condition=" '$(OS)' == 'Windows_NT'">"$(NuGetExePath)"</NuGetCommand>
+        <NuGetCommand Condition=" '$(OS)' != 'Windows_NT' ">mono --runtime=v4.0.30319 $(NuGetExePath)</NuGetCommand>
+
+        <PackageOutputDir Condition="$(PackageOutputDir) == ''">$(TargetDir.Trim('\\'))</PackageOutputDir>
+        
+        <RequireConsentSwitch Condition=" $(RequireRestoreConsent) == 'true' ">-RequireConsent</RequireConsentSwitch>
+        <!-- Commands -->
+        <RestoreCommand>$(NuGetCommand) install "$(PackagesConfig)" -source "$(PackageSources)"  $(RequireConsentSwitch) -o "$(PackagesDir)"</RestoreCommand>
+        <BuildCommand>$(NuGetCommand) pack "$(ProjectPath)" -p Configuration=$(Configuration) -o "$(PackageOutputDir)" -symbols</BuildCommand>
+
+        <!-- Make the build depend on restore packages -->
+        <BuildDependsOn Condition="$(RestorePackages) == 'true'">
+            RestorePackages;
+            $(BuildDependsOn);
+        </BuildDependsOn>
+
+        <!-- Make the build depend on restore packages -->
+        <BuildDependsOn Condition="$(BuildPackage) == 'true'">
+            $(BuildDependsOn);
+            BuildPackage;
+        </BuildDependsOn>
+    </PropertyGroup>
+
+    <Target Name="CheckPrerequisites">
+        <!-- Raise an error if we're unable to locate nuget.exe  -->
+        <Error Condition="'$(DownloadNuGetExe)' != 'true' AND !Exists('$(NuGetExePath)')" Text="Unable to locate '$(NuGetExePath)'" />
+        <SetEnvironmentVariable EnvKey="VisualStudioVersion" EnvValue="$(VisualStudioVersion)" Condition=" '$(VisualStudioVersion)' != '' AND '$(OS)' == 'Windows_NT' " />
+        <!--
+        Take advantage of MsBuild's build dependency tracking to make sure that we only ever download nuget.exe once. This effectively acts as
+        a lock that makes sure that the download operation will only happen once and all parallel builds will have to wait for it to complete.
+        -->
+        <MsBuild Targets="_DownloadNuGet" Projects="$(MSBuildThisFileFullPath)" Properties="Configuration=NOT_IMPORTANT" />
+    </Target>
+
+    <Target Name="_DownloadNuGet">
+        <DownloadNuGet OutputFilename="$(NuGetExePath)" Condition=" '$(DownloadNuGetExe)' == 'true' AND !Exists('$(NuGetExePath)')"  />
+    </Target>
+
+    <Target Name="RestorePackages" DependsOnTargets="CheckPrerequisites">
+        <Exec Command="$(RestoreCommand)"
+              Condition="'$(OS)' != 'Windows_NT' And Exists('$(PackagesConfig)')" />
+              
+        <Exec Command="$(RestoreCommand)"
+              LogStandardErrorAsError="true"
+              Condition="'$(OS)' == 'Windows_NT' And Exists('$(PackagesConfig)')" />
+    </Target>
+
+    <Target Name="BuildPackage" DependsOnTargets="CheckPrerequisites">
+        <Exec Command="$(BuildCommand)" 
+              Condition=" '$(OS)' != 'Windows_NT' " />
+              
+        <Exec Command="$(BuildCommand)"
+              LogStandardErrorAsError="true"
+              Condition=" '$(OS)' == 'Windows_NT' " />
+    </Target>
+    
+    <UsingTask TaskName="DownloadNuGet" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+        <ParameterGroup>
+            <OutputFilename ParameterType="System.String" Required="true" />
+        </ParameterGroup>
+        <Task>
+            <Reference Include="System.Core" />
+            <Using Namespace="System" />
+            <Using Namespace="System.IO" />
+            <Using Namespace="System.Net" />
+            <Using Namespace="Microsoft.Build.Framework" />
+            <Using Namespace="Microsoft.Build.Utilities" />
+            <Code Type="Fragment" Language="cs">
+                <![CDATA[
+                try {
+                    OutputFilename = Path.GetFullPath(OutputFilename);
+
+                    Log.LogMessage("Downloading latest version of NuGet.exe...");
+                    WebClient webClient = new WebClient();
+                    webClient.DownloadFile("https://nuget.org/nuget.exe", OutputFilename);
+
+                    return true;
+                }
+                catch (Exception ex) {
+                    Log.LogErrorFromException(ex);
+                    return false;
+                }
+            ]]>
+            </Code>
+        </Task>
+    </UsingTask>
+    
+     <UsingTask TaskName="SetEnvironmentVariable" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+        <ParameterGroup>
+            <EnvKey ParameterType="System.String" Required="true" />
+            <EnvValue ParameterType="System.String" Required="true" />
+        </ParameterGroup>
+        <Task>
+            <Using Namespace="System" />
+            <Code Type="Fragment" Language="cs">
+                <![CDATA[
+                try {
+                    Environment.SetEnvironmentVariable(EnvKey, EnvValue, System.EnvironmentVariableTarget.Process);
+                }
+                catch  {
+                }
+            ]]>
+            </Code>
+        </Task>
+    </UsingTask>
+</Project>

--- a/samples/Sample.NetFramework451.WebApp/Program.cs
+++ b/samples/Sample.NetFramework451.WebApp/Program.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Net.Http;
+using Newtonsoft.Json.Linq;
+
+namespace WorldBankSample
+{
+    /// <summary>
+    /// Sample download list of countries from the World Bank Data sources at http://data.worldbank.org/
+    /// </summary>
+    class Program
+    {
+        private static string _address = "http://api.worldbank.org/countries?format=json";
+
+        private static async void RunClient()
+        {
+            // Create an HttpClient instance
+            HttpClient client = new HttpClient();
+
+            // Send a request asynchronously and continue when complete
+            HttpResponseMessage response = await client.GetAsync(_address);
+
+            // Check that response was successful or throw exception
+            response.EnsureSuccessStatusCode();
+
+            // Read response asynchronously as JToken and write out top facts for each country
+            JArray content = await response.Content.ReadAsAsync<JArray>();
+
+            Console.WriteLine("First 50 countries listed by The World Bank...");
+            foreach (var country in content[1])
+            {
+                Console.WriteLine("   {0}, Country Code: {1}, Capital: {2}, Latitude: {3}, Longitude: {4}",
+                    country.Value<string>("name"),
+                    country.Value<string>("iso2Code"),
+                    country.Value<string>("capitalCity"),
+                    country.Value<string>("latitude"),
+                    country.Value<string>("longitude"));
+            }
+        }
+
+        static void Main(string[] args)
+        {
+            RunClient();
+
+            Console.WriteLine("Hit ENTER to exit...");
+            Console.ReadLine();
+        }
+    }
+}

--- a/samples/Sample.NetFramework451.WebApp/Properties/AssemblyInfo.cs
+++ b/samples/Sample.NetFramework451.WebApp/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("BingTranslateSample")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("BingTranslateSample")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("3ca01724-9221-48c9-ae95-a09c131cd89d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/samples/Sample.NetFramework451.WebApp/ReadMe.txt
+++ b/samples/Sample.NetFramework451.WebApp/ReadMe.txt
@@ -1,0 +1,8 @@
+WorldBankSample
+---------------
+
+This sample shows how to retrieve data from the World Bank data site using JSON.NET to parse 
+the result as JToken.
+
+For a detailed description of this sample, please see
+http://blogs.msdn.com/b/henrikn/archive/2012/02/16/httpclient-is-here.aspx

--- a/samples/Sample.NetFramework451.WebApp/WorldBankSample.csproj
+++ b/samples/Sample.NetFramework451.WebApp/WorldBankSample.csproj
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{14D3B6F1-E240-4C4A-8176-FB2911741EA1}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>WorldBankSample</RootNamespace>
+    <AssemblyName>WorldBankSample</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">.\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>packages\Newtonsoft.Json.4.5.6\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.AspNet.WebApi.Client.4.0.20710.0\lib\net40\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/samples/Sample.NetFramework451.WebApp/WorldBankSample.sln
+++ b/samples/Sample.NetFramework451.WebApp/WorldBankSample.sln
@@ -1,0 +1,38 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WorldBankSample", "WorldBankSample.csproj", "{14D3B6F1-E240-4C4A-8176-FB2911741EA1}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{A297F50D-1F11-4F84-A94B-96B7C0DC1BF8}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\NuGet.Config = .nuget\NuGet.Config
+		.nuget\NuGet.exe = .nuget\NuGet.exe
+		.nuget\NuGet.targets = .nuget\NuGet.targets
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0D39AE07-10FB-4D9D-A6F2-0F7988E25002}"
+	ProjectSection(SolutionItems) = preProject
+		ReadMe.txt = ReadMe.txt
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{14D3B6F1-E240-4C4A-8176-FB2911741EA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{14D3B6F1-E240-4C4A-8176-FB2911741EA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{14D3B6F1-E240-4C4A-8176-FB2911741EA1}.Debug|x86.ActiveCfg = Debug|x86
+		{14D3B6F1-E240-4C4A-8176-FB2911741EA1}.Debug|x86.Build.0 = Debug|x86
+		{14D3B6F1-E240-4C4A-8176-FB2911741EA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{14D3B6F1-E240-4C4A-8176-FB2911741EA1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{14D3B6F1-E240-4C4A-8176-FB2911741EA1}.Release|x86.ActiveCfg = Release|x86
+		{14D3B6F1-E240-4C4A-8176-FB2911741EA1}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/samples/Sample.NetFramework451.WebApp/app.config
+++ b/samples/Sample.NetFramework451.WebApp/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/samples/Sample.NetFramework451.WebApp/packages.config
+++ b/samples/Sample.NetFramework451.WebApp/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.WebApi.Client" version="4.0.20710.0" targetFramework="net45" />
+  <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="4.5.6" targetFramework="net45" />
+</packages>

--- a/src/DotNetCensus.Core/Projects/ProjectClassification.cs
+++ b/src/DotNetCensus.Core/Projects/ProjectClassification.cs
@@ -70,7 +70,6 @@ public static class ProjectClassification
 
     public static string GetFriendlyName(string frameworkCode, string family)
     {
-
         if (string.IsNullOrEmpty(frameworkCode))
         {
             return "(Unknown)";
@@ -91,6 +90,10 @@ public static class ProjectClassification
         {
             string number = frameworkCode.Replace("net", "");
             StringBuilder formattedNumber = new();
+            if (frameworkCode == "net451")
+            {
+                int j = 0;
+            }
             //Add .'s between each number. Gross. (e.g. net462 becomes 4.6.2)
             for (int i = 0; i < number.Length; i++)
             {
@@ -193,7 +196,7 @@ public static class ProjectClassification
             framework.Contains("v4.5") ||
             framework == "v4.6" || //Unclear if this should be net46 or v4.6 - I've seen both in wild
             framework == "v4.6.1" || //Unclear if this should be net461 or v4.6.1 - I've seen both in wild
-            framework == "net45" || //Unclear if this should be net45 or v4.5 - I've seen both in wild
+            framework.Contains("net45") || //Unclear if this should be net45 or v4.5 - I've seen both in wild
             framework == "net46" ||
             framework == "net461" ||
             framework.Contains("netcoreapp1") ||

--- a/src/DotNetCensus.Core/Projects/ProjectFileProcessing.cs
+++ b/src/DotNetCensus.Core/Projects/ProjectFileProcessing.cs
@@ -268,6 +268,7 @@ namespace DotNetCensus.Core.Projects
                 item.Status = ProjectClassification.GetStatus(item.FrameworkCode);
                 item.Family = ProjectClassification.GetFrameworkFamily(item.FrameworkCode);
                 item.FrameworkName = ProjectClassification.GetFriendlyName(item.FrameworkCode, item.Family);
+                //Debug.WriteLine($"Framework: {item.FrameworkCode}; Name: {item.FrameworkName}; Project: {item.FileName}");
             }
 
             return projects;

--- a/src/DotNetCensus.Tests/ConsoleDirectoryAppTests.cs
+++ b/src/DotNetCensus.Tests/ConsoleDirectoryAppTests.cs
@@ -112,6 +112,7 @@ public class ConsoleDirectoryAppTests : DirectoryBasedTests
 .NET Framework 3.5,.NET Framework,2,EOL: 9-Jan-2029
 .NET Framework 4.0,.NET Framework,1,deprecated
 .NET Framework 4.5,.NET Framework,1,deprecated
+.NET Framework 4.5.1,.NET Framework,1,deprecated
 .NET Framework 4.6.1,.NET Framework,1,deprecated
 .NET Framework 4.6.2,.NET Framework,1,supported
 .NET Framework 4.7.1,.NET Framework,1,supported
@@ -119,7 +120,7 @@ public class ConsoleDirectoryAppTests : DirectoryBasedTests
 .NET Standard 2.0,.NET Standard,3,supported
 (Unknown),(Unknown),2,unknown
 Visual Basic 6,Visual Basic 6,1,deprecated
-total frameworks,,45,
+total frameworks,,46,
 ";
 
             //Act

--- a/src/DotNetCensus.Tests/ConsoleDirectoryAppTests.cs
+++ b/src/DotNetCensus.Tests/ConsoleDirectoryAppTests.cs
@@ -57,6 +57,7 @@ public class ConsoleDirectoryAppTests : DirectoryBasedTests
 /Sample.NETFramework4.6.1FSharp.HelloWorld/HelloWorld.fsproj,HelloWorld.fsproj,net461,.NET Framework 4.6.1,.NET Framework,fsharp,deprecated
 /Sample.NetFramework40.WebApp/WorldBankSample.csproj,WorldBankSample.csproj,v4.0,.NET Framework 4.0,.NET Framework,csharp,deprecated
 /Sample.NetFramework45.WebApp/WorldBankSample.csproj,WorldBankSample.csproj,v4.5,.NET Framework 4.5,.NET Framework,csharp,deprecated
+/Sample.NetFramework451.WebApp/WorldBankSample.csproj,WorldBankSample.csproj,v4.5.1,.NET Framework 4.5.1,.NET Framework,csharp,deprecated
 /Sample.NetFrameworkInvalid.App/VBProj.vbproj,VBProj.vbproj,,(Unknown),(Unknown),vb.net,unknown
 /Sample.NetFrameworkVBNet.ConsoleApp/Sample.NetFrameworkVBNet.ConsoleApp.vbproj,Sample.NetFrameworkVBNet.ConsoleApp.vbproj,netcoreapp3.1,.NET Core 3.1,.NET Core,vb.net,deprecated
 /Sample.NetStandard.Class/Sample.NetStandard.Class.csproj,Sample.NetStandard.Class.csproj,netstandard2.0,.NET Standard 2.0,.NET Standard,csharp,supported

--- a/src/DotNetCensus.Tests/ConsoleRepoAppTests.cs
+++ b/src/DotNetCensus.Tests/ConsoleRepoAppTests.cs
@@ -100,6 +100,7 @@ total frameworks                       50
 .NET Framework 3.5    .NET Framework   2      EOL: 9-Jan-2029
 .NET Framework 4.0    .NET Framework   1      deprecated     
 .NET Framework 4.5    .NET Framework   1      deprecated     
+.NET Framework 4.5.1  .NET Framework   1      deprecated     
 .NET Framework 4.6.1  .NET Framework   1      deprecated     
 .NET Framework 4.6.2  .NET Framework   1      supported      
 .NET Framework 4.7.1  .NET Framework   1      supported      
@@ -107,7 +108,7 @@ total frameworks                       50
 .NET Standard 2.0     .NET Standard    3      supported      
 (Unknown)             (Unknown)        2      unknown        
 Visual Basic 6        Visual Basic 6   1      deprecated     
-total frameworks                       50                    
+total frameworks                       51                    
 
 ";
 

--- a/src/DotNetCensus.Tests/DirectoryDataAccessTests.cs
+++ b/src/DotNetCensus.Tests/DirectoryDataAccessTests.cs
@@ -106,7 +106,7 @@ Visual Basic 6        Visual Basic 6   1      deprecated
     {
         //Arrange
         bool includeTotals = true;
-        string? directory = null;
+        string? directory = SamplesPath;
         Repo? repo = null;
         string? file = null;
         if (directory != null || repo != null)
@@ -156,7 +156,7 @@ total frameworks                       33
     {
         //Arrange
         bool includeTotals = true;
-        string? directory = null;
+        string? directory = SamplesPath;
         Repo? repo = null;
         string? file = "test.txt";
         if (directory != null || repo != null)
@@ -204,7 +204,7 @@ total frameworks,,33,
     public void InventoryResultsTest()
     {
         //Arrange
-        string? directory = null;
+        string? directory = SamplesPath;
         Repo? repo = null;
         string? file = null;
         if (directory != null || repo != null)
@@ -289,7 +289,7 @@ total frameworks,,33,
     public void InventoryResultsWebConfigCountTest()
     {
         //Arrange
-        string? directory = null;
+        string? directory = SamplesPath;
         Repo? repo = null;
         string? file = null;
         int webConfigCount = 0;
@@ -320,7 +320,7 @@ total frameworks,,33,
     public void InventoryResultsToFileTest()
     {
         //Arrange
-        string? directory = null;
+        string? directory = SamplesPath;
         Repo? repo = null;
         string? file = "test2.txt";
         if (directory != null || repo != null)
@@ -370,8 +370,6 @@ total frameworks,,33,
             Assert.AreEqual(expected.Replace("\\", "/"), contents.Replace("\\", "/"));
         }
     }
-
-
 
     [TestMethod]
     public void FrameworkSummaryMultipleDirectoryMAUICalculatorResultsTest()

--- a/src/DotNetCensus.Tests/DirectoryDataAccessTests.cs
+++ b/src/DotNetCensus.Tests/DirectoryDataAccessTests.cs
@@ -59,6 +59,7 @@ public class DirectoryDataAccessTests : DirectoryBasedTests
 .NET Framework 3.5    .NET Framework   2      EOL: 9-Jan-2029
 .NET Framework 4.0    .NET Framework   1      deprecated     
 .NET Framework 4.5    .NET Framework   1      deprecated     
+.NET Framework 4.5.1  .NET Framework   1      deprecated     
 .NET Framework 4.6.1  .NET Framework   1      deprecated     
 .NET Framework 4.6.2  .NET Framework   1      supported      
 .NET Framework 4.7.1  .NET Framework   1      supported      
@@ -111,34 +112,37 @@ Visual Basic 6        Visual Basic 6   1      deprecated
         string? file = null;
         if (directory != null || repo != null)
         {
-            string expected = @"Framework             FrameworkFamily  Count  Status          
---------------------------------------------------------------
-.NET 5.0              .NET             1      deprecated      
-.NET 6.0              .NET             4      supported       
-.NET 6.0-android      .NET             1      supported       
-.NET 6.0-ios          .NET             1      supported       
-.NET 7.0              .NET             1      in preview      
-.NET Core 1.0         .NET Core        1      deprecated      
-.NET Core 1.1         .NET Core        1      deprecated      
-.NET Core 2.0         .NET Core        1      deprecated      
-.NET Core 2.1         .NET Core        1      deprecated      
-.NET Core 2.2         .NET Core        1      deprecated      
-.NET Core 3.0         .NET Core        2      deprecated      
-.NET Core 3.1         .NET Core        3      deprecated
-.NET Framework 1.0    .NET Framework   1      deprecated      
-.NET Framework 1.1    .NET Framework   1      deprecated      
-.NET Framework 2.0    .NET Framework   1      deprecated      
-.NET Framework 3.5    .NET Framework   2      EOL: 9-Jan-2029 
-.NET Framework 4.0    .NET Framework   1      deprecated      
-.NET Framework 4.5    .NET Framework   1      deprecated      
-.NET Framework 4.6.1  .NET Framework   1      deprecated      
-.NET Framework 4.6.2  .NET Framework   1      supported       
-.NET Framework 4.7.1  .NET Framework   1      supported       
-.NET Framework 4.7.2  .NET Framework   2      supported       
-.NET Standard 2.0     .NET Standard    1      supported       
-(Unknown)             (Unknown)        1      unknown         
-Visual Basic 6        Visual Basic 6   1      deprecated      
-total frameworks                       33                     
+            string expected = @"Framework             FrameworkFamily  Count  Status         
+-------------------------------------------------------------
+.NET 5.0              .NET             2      deprecated     
+.NET 6.0              .NET             4      supported      
+.NET 6.0-android      .NET             1      supported      
+.NET 6.0-ios          .NET             1      supported      
+.NET 6.0-maccatalyst  .NET             1      supported      
+.NET 7.0              .NET             2      supported      
+.NET 8.0              .NET             5      in preview     
+.NET Core 1.0         .NET Core        1      deprecated     
+.NET Core 1.1         .NET Core        1      deprecated     
+.NET Core 2.0         .NET Core        1      deprecated     
+.NET Core 2.1         .NET Core        1      deprecated     
+.NET Core 2.2         .NET Core        1      deprecated     
+.NET Core 3.0         .NET Core        2      deprecated     
+.NET Core 3.1         .NET Core        3      deprecated     
+.NET Framework 1.0    .NET Framework   1      deprecated     
+.NET Framework 1.1    .NET Framework   1      deprecated     
+.NET Framework 2.0    .NET Framework   1      deprecated     
+.NET Framework 3.5    .NET Framework   2      EOL: 9-Jan-2029
+.NET Framework 4.0    .NET Framework   1      deprecated     
+.NET Framework 4.5    .NET Framework   1      deprecated     
+.NET Framework 4.5.1  .NET Framework   1      deprecated     
+.NET Framework 4.6.1  .NET Framework   1      deprecated     
+.NET Framework 4.6.2  .NET Framework   1      supported      
+.NET Framework 4.7.1  .NET Framework   1      supported      
+.NET Framework 4.7.2  .NET Framework   3      supported      
+.NET Standard 2.0     .NET Standard    3      supported      
+(Unknown)             (Unknown)        2      unknown        
+Visual Basic 6        Visual Basic 6   1      deprecated     
+total frameworks                       46                    
 ";
 
             //Act
@@ -162,11 +166,13 @@ total frameworks                       33
         if (directory != null || repo != null)
         {
             string expected = @"Framework,FrameworkFamily,Count,Status
-.NET 5.0,.NET,1,deprecated
+.NET 5.0,.NET,2,deprecated
 .NET 6.0,.NET,4,supported
 .NET 6.0-android,.NET,1,supported
 .NET 6.0-ios,.NET,1,supported
-.NET 7.0,.NET,1,in preview
+.NET 6.0-maccatalyst,.NET,1,supported
+.NET 7.0,.NET,2,supported
+.NET 8.0,.NET,5,in preview
 .NET Core 1.0,.NET Core,1,deprecated
 .NET Core 1.1,.NET Core,1,deprecated
 .NET Core 2.0,.NET Core,1,deprecated
@@ -180,14 +186,15 @@ total frameworks                       33
 .NET Framework 3.5,.NET Framework,2,EOL: 9-Jan-2029
 .NET Framework 4.0,.NET Framework,1,deprecated
 .NET Framework 4.5,.NET Framework,1,deprecated
+.NET Framework 4.5.1,.NET Framework,1,deprecated
 .NET Framework 4.6.1,.NET Framework,1,deprecated
 .NET Framework 4.6.2,.NET Framework,1,supported
 .NET Framework 4.7.1,.NET Framework,1,supported
-.NET Framework 4.7.2,.NET Framework,2,supported
-.NET Standard 2.0,.NET Standard,1,supported
-(Unknown),(Unknown),1,unknown
+.NET Framework 4.7.2,.NET Framework,3,supported
+.NET Standard 2.0,.NET Standard,3,supported
+(Unknown),(Unknown),2,unknown
 Visual Basic 6,Visual Basic 6,1,deprecated
-total frameworks,,33,
+total frameworks,,46,
 ";
 
             //Act
@@ -209,41 +216,54 @@ total frameworks,,33,
         string? file = null;
         if (directory != null || repo != null)
         {
-            string expected = @"Path                                                                             FileName                                    FrameworkCode   FrameworkName         Family          Language  Status          
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-/Sample.MultipleTargets.ConsoleApp/Sample.MultipleTargets.ConsoleApp.csproj      Sample.MultipleTargets.ConsoleApp.csproj    netcoreapp3.1   .NET Core 3.1         .NET Core       csharp    deprecated
-/Sample.MultipleTargets.ConsoleApp/Sample.MultipleTargets.ConsoleApp.csproj      Sample.MultipleTargets.ConsoleApp.csproj    net462          .NET Framework 4.6.2  .NET Framework  csharp    supported       
-/Sample.Net5.ConsoleApp/Sample.Net5.ConsoleApp.csproj                            Sample.Net5.ConsoleApp.csproj               net5.0          .NET 5.0              .NET            csharp    deprecated      
-/Sample.Net6.ConsoleApp/Sample.Net6.ConsoleApp.csproj                            Sample.Net6.ConsoleApp.csproj               net6.0          .NET 6.0              .NET            csharp    supported       
-/Sample.Net6.ConsoleApp2/src/Sample.Net6.ConsoleApp.csproj                       Sample.Net6.ConsoleApp.csproj               net6.0          .NET 6.0              .NET            csharp    supported       
-/Sample.NET6.Directory.Build.props/App1/Sample.Net6.ConsoleApp.csproj            Sample.Net6.ConsoleApp.csproj               net6.0          .NET 6.0              .NET            csharp    supported       
-/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                    Calculator.csproj                           net6.0-ios      .NET 6.0-ios          .NET            csharp    supported       
-/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                    Calculator.csproj                           net6.0-android  .NET 6.0-android      .NET            csharp    supported       
-/Sample.Net6Inception.ConsoleApp/Sample.Net6.ConsoleApp.csproj                   Sample.Net6.ConsoleApp.csproj               net6.0          .NET 6.0              .NET            csharp    supported       
-/Sample.Net7.ConsoleApp/Sample.Net7.ConsoleApp.csproj                            Sample.Net7.ConsoleApp.csproj               net7.0          .NET 7.0              .NET            csharp    in preview      
-/Sample.NetCore1.0.ConsoleApp/project.json                                       project.json                                netcoreapp1.0   .NET Core 1.0         .NET Core       csharp    deprecated      
-/Sample.NetCore1.1.ConsoleApp/project.json                                       project.json                                netcoreapp1.1   .NET Core 1.1         .NET Core       csharp    deprecated      
-/Sample.NetCore2.0.ConsoleApp/Sample.NetCore2.0.ConsoleApp.csproj                Sample.NetCore2.0.ConsoleApp.csproj         netcoreapp2.0   .NET Core 2.0         .NET Core       csharp    deprecated      
-/Sample.NetCore2.1.ConsoleApp/Sample.NetCore2.1.ConsoleApp.csproj                Sample.NetCore2.1.ConsoleApp.csproj         netcoreapp2.1   .NET Core 2.1         .NET Core       csharp    deprecated      
-/Sample.NetCore2.2.ConsoleApp/Sample.NetCore2.2.ConsoleApp.csproj                Sample.NetCore2.2.ConsoleApp.csproj         netcoreapp2.2   .NET Core 2.2         .NET Core       csharp    deprecated      
-/Sample.NetCore3.0.ConsoleApp/Sample.NetCore3.0.ConsoleApp.csproj                Sample.NetCore3.0.ConsoleApp.csproj         netcoreapp3.0   .NET Core 3.0         .NET Core       csharp    deprecated      
-/Sample.NetCore3.0.fsharp.ConsoleApp/hello-world-fsharp.fsproj                   hello-world-fsharp.fsproj                   netcoreapp3.0   .NET Core 3.0         .NET Core       fsharp    deprecated      
-/Sample.NetCore3.1.ConsoleApp/Sample.NetCore.ConsoleApp.csproj                   Sample.NetCore.ConsoleApp.csproj            netcoreapp3.1   .NET Core 3.1         .NET Core       csharp    deprecated
-/Sample.NetFramework.ConsoleApp/Sample.NetFramework.ConsoleApp.csproj            Sample.NetFramework.ConsoleApp.csproj       v4.7.2          .NET Framework 4.7.2  .NET Framework  csharp    supported       
-/Sample.NetFramework1.0.App/VBProj.vbproj                                        VBProj.vbproj                               v1.0            .NET Framework 1.0    .NET Framework  vb.net    deprecated      
-/Sample.NetFramework1.1.App/VBProj.vbproj                                        VBProj.vbproj                               v1.1            .NET Framework 1.1    .NET Framework  vb.net    deprecated      
-/Sample.NetFramework2.0.App/VBProj.vbproj                                        VBProj.vbproj                               v2.0            .NET Framework 2.0    .NET Framework  vb.net    deprecated      
-/Sample.NetFramework3.5.WebApp/dotnetapp-3.5.csproj                              dotnetapp-3.5.csproj                        v3.5            .NET Framework 3.5    .NET Framework  csharp    EOL: 9-Jan-2029 
-/Sample.NetFramework3.5.Website/web.config                                       web.config                                  v3.5            .NET Framework 3.5    .NET Framework  csharp    EOL: 9-Jan-2029 
-/Sample.NETFramework4.6.1FSharp.HelloWorld/HelloWorld.fsproj                     HelloWorld.fsproj                           net461          .NET Framework 4.6.1  .NET Framework  fsharp    deprecated      
-/Sample.NetFramework40.WebApp/WorldBankSample.csproj                             WorldBankSample.csproj                      v4.0            .NET Framework 4.0    .NET Framework  csharp    deprecated      
-/Sample.NetFramework45.WebApp/WorldBankSample.csproj                             WorldBankSample.csproj                      v4.5            .NET Framework 4.5    .NET Framework  csharp    deprecated      
-/Sample.NetFrameworkInvalid.App/VBProj.vbproj                                    VBProj.vbproj                                               (Unknown)             (Unknown)       vb.net    unknown         
-/Sample.NetFrameworkVBNet.ConsoleApp/Sample.NetFrameworkVBNet.ConsoleApp.vbproj  Sample.NetFrameworkVBNet.ConsoleApp.vbproj  netcoreapp3.1   .NET Core 3.1         .NET Core       vb.net    deprecated
-/Sample.NetStandard.Class/Sample.NetStandard.Class.csproj                        Sample.NetStandard.Class.csproj             netstandard2.0  .NET Standard 2.0     .NET Standard   csharp    supported       
-/Sample.SSDT.Database/Sample.SSDT.Database.sqlproj                               Sample.SSDT.Database.sqlproj                v4.7.2          .NET Framework 4.7.2  .NET Framework  csharp    supported       
-/Sample.Unity2020/Assembly-CSharp.csproj                                         Assembly-CSharp.csproj                      v4.7.1          .NET Framework 4.7.1  .NET Framework  csharp    supported       
-/Sample.VB6.Calculator/Sample.VB6.WinApp.vbp                                     Sample.VB6.WinApp.vbp                       vb6             Visual Basic 6        Visual Basic 6  vb6       deprecated      
+            string expected = @"Path                                                                                                            FileName                                    FrameworkCode       FrameworkName         Family          Language  Status         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+/Sample.Multiple.Directory.Build.Props/src/tools/illink/src/analyzer/analyzer.csproj                            analyzer.csproj                             net8.0              .NET 8.0              .NET            csharp    in preview     
+/Sample.Multiple.Directory.Build.Props/src/tools/illink/src/ILLink.CodeFix/ILLink.CodeFixProvider.csproj        ILLink.CodeFixProvider.csproj               netstandard2.0      .NET Standard 2.0     .NET Standard   csharp    supported      
+/Sample.Multiple.Directory.Build.Props/src/tools/illink/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj  ILLink.RoslynAnalyzer.csproj                netstandard2.0      .NET Standard 2.0     .NET Standard   csharp    supported      
+/Sample.Multiple.Directory.Build.Props/src/tools/illink/src/ILLink.Tasks/ILLink.Tasks.csproj                    ILLink.Tasks.csproj                         net472              .NET Framework 4.7.2  .NET Framework  csharp    supported      
+/Sample.Multiple.Directory.Build.Props/src/tools/illink/src/ILLink.Tasks/ILLink.Tasks.csproj                    ILLink.Tasks.csproj                                             (Unknown)             (Unknown)       csharp    unknown        
+/Sample.Multiple.Directory.Build.Props/src/tools/illink/src/ILLink.Tasks/ILLink.Tasks.csproj                    ILLink.Tasks.csproj                         net8.0              .NET 8.0              .NET            csharp    in preview     
+/Sample.Multiple.Directory.Build.Props/src/tools/illink/src/linker/Mono.Linker.csproj                           Mono.Linker.csproj                          net8.0              .NET 8.0              .NET            csharp    in preview     
+/Sample.Multiple.Directory.Build.Props/src/tools/illink/src/tlens/tlens.csproj                                  tlens.csproj                                net8.0              .NET 8.0              .NET            csharp    in preview     
+/Sample.MultipleTargets.ConsoleApp/Sample.MultipleTargets.ConsoleApp.csproj                                     Sample.MultipleTargets.ConsoleApp.csproj    netcoreapp3.1       .NET Core 3.1         .NET Core       csharp    deprecated     
+/Sample.MultipleTargets.ConsoleApp/Sample.MultipleTargets.ConsoleApp.csproj                                     Sample.MultipleTargets.ConsoleApp.csproj    net5.0              .NET 5.0              .NET            csharp    deprecated     
+/Sample.MultipleTargets.ConsoleApp/Sample.MultipleTargets.ConsoleApp.csproj                                     Sample.MultipleTargets.ConsoleApp.csproj    net462              .NET Framework 4.6.2  .NET Framework  csharp    supported      
+/Sample.Net5.ConsoleApp/Sample.Net5.ConsoleApp.csproj                                                           Sample.Net5.ConsoleApp.csproj               net5.0              .NET 5.0              .NET            csharp    deprecated     
+/Sample.Net6.ConsoleApp/Sample.Net6.ConsoleApp.csproj                                                           Sample.Net6.ConsoleApp.csproj               net6.0              .NET 6.0              .NET            csharp    supported      
+/Sample.Net6.ConsoleApp2/src/Sample.Net6.ConsoleApp.csproj                                                      Sample.Net6.ConsoleApp.csproj               net6.0              .NET 6.0              .NET            csharp    supported      
+/Sample.NET6.Directory.Build.props/App1/Sample.Net6.ConsoleApp.csproj                                           Sample.Net6.ConsoleApp.csproj               net6.0              .NET 6.0              .NET            csharp    supported      
+/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                                                   Calculator.csproj                           net6.0-ios          .NET 6.0-ios          .NET            csharp    supported      
+/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                                                   Calculator.csproj                           net6.0-maccatalyst  .NET 6.0-maccatalyst  .NET            csharp    supported      
+/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                                                   Calculator.csproj                           net6.0-android      .NET 6.0-android      .NET            csharp    supported      
+/Sample.Net6Inception.ConsoleApp/Sample.Net6.ConsoleApp.csproj                                                  Sample.Net6.ConsoleApp.csproj               net6.0              .NET 6.0              .NET            csharp    supported      
+/Sample.Net7.ConsoleApp/Sample.Net7.ConsoleApp.csproj                                                           Sample.Net7.ConsoleApp.csproj               net7.0              .NET 7.0              .NET            csharp    supported      
+/Sample.Net7.ConsoleApp2/Sample.Net7.ConsoleApp2.csproj                                                         Sample.Net7.ConsoleApp2.csproj              net7.0              .NET 7.0              .NET            csharp    supported      
+/Sample.Net8.ConsoleApp/Sample.Net8.ConsoleApp.csproj                                                           Sample.Net8.ConsoleApp.csproj               net8.0              .NET 8.0              .NET            csharp    in preview     
+/Sample.NetCore1.0.ConsoleApp/project.json                                                                      project.json                                netcoreapp1.0       .NET Core 1.0         .NET Core       csharp    deprecated     
+/Sample.NetCore1.1.ConsoleApp/project.json                                                                      project.json                                netcoreapp1.1       .NET Core 1.1         .NET Core       csharp    deprecated     
+/Sample.NetCore2.0.ConsoleApp/Sample.NetCore2.0.ConsoleApp.csproj                                               Sample.NetCore2.0.ConsoleApp.csproj         netcoreapp2.0       .NET Core 2.0         .NET Core       csharp    deprecated     
+/Sample.NetCore2.1.ConsoleApp/Sample.NetCore2.1.ConsoleApp.csproj                                               Sample.NetCore2.1.ConsoleApp.csproj         netcoreapp2.1       .NET Core 2.1         .NET Core       csharp    deprecated     
+/Sample.NetCore2.2.ConsoleApp/Sample.NetCore2.2.ConsoleApp.csproj                                               Sample.NetCore2.2.ConsoleApp.csproj         netcoreapp2.2       .NET Core 2.2         .NET Core       csharp    deprecated     
+/Sample.NetCore3.0.ConsoleApp/Sample.NetCore3.0.ConsoleApp.csproj                                               Sample.NetCore3.0.ConsoleApp.csproj         netcoreapp3.0       .NET Core 3.0         .NET Core       csharp    deprecated     
+/Sample.NetCore3.0.fsharp.ConsoleApp/hello-world-fsharp.fsproj                                                  hello-world-fsharp.fsproj                   netcoreapp3.0       .NET Core 3.0         .NET Core       fsharp    deprecated     
+/Sample.NetCore3.1.ConsoleApp/Sample.NetCore.ConsoleApp.csproj                                                  Sample.NetCore.ConsoleApp.csproj            netcoreapp3.1       .NET Core 3.1         .NET Core       csharp    deprecated     
+/Sample.NetFramework.ConsoleApp/Sample.NetFramework.ConsoleApp.csproj                                           Sample.NetFramework.ConsoleApp.csproj       v4.7.2              .NET Framework 4.7.2  .NET Framework  csharp    supported      
+/Sample.NetFramework1.0.App/VBProj.vbproj                                                                       VBProj.vbproj                               v1.0                .NET Framework 1.0    .NET Framework  vb.net    deprecated     
+/Sample.NetFramework1.1.App/VBProj.vbproj                                                                       VBProj.vbproj                               v1.1                .NET Framework 1.1    .NET Framework  vb.net    deprecated     
+/Sample.NetFramework2.0.App/VBProj.vbproj                                                                       VBProj.vbproj                               v2.0                .NET Framework 2.0    .NET Framework  vb.net    deprecated     
+/Sample.NetFramework3.5.WebApp/dotnetapp-3.5.csproj                                                             dotnetapp-3.5.csproj                        v3.5                .NET Framework 3.5    .NET Framework  csharp    EOL: 9-Jan-2029
+/Sample.NetFramework3.5.Website/web.config                                                                      web.config                                  v3.5                .NET Framework 3.5    .NET Framework  csharp    EOL: 9-Jan-2029
+/Sample.NETFramework4.6.1FSharp.HelloWorld/HelloWorld.fsproj                                                    HelloWorld.fsproj                           net461              .NET Framework 4.6.1  .NET Framework  fsharp    deprecated     
+/Sample.NetFramework40.WebApp/WorldBankSample.csproj                                                            WorldBankSample.csproj                      v4.0                .NET Framework 4.0    .NET Framework  csharp    deprecated     
+/Sample.NetFramework45.WebApp/WorldBankSample.csproj                                                            WorldBankSample.csproj                      v4.5                .NET Framework 4.5    .NET Framework  csharp    deprecated     
+/Sample.NetFramework451.WebApp/WorldBankSample.csproj                                                           WorldBankSample.csproj                      v4.5.1              .NET Framework 4.5.1  .NET Framework  csharp    deprecated     
+/Sample.NetFrameworkInvalid.App/VBProj.vbproj                                                                   VBProj.vbproj                                                   (Unknown)             (Unknown)       vb.net    unknown        
+/Sample.NetFrameworkVBNet.ConsoleApp/Sample.NetFrameworkVBNet.ConsoleApp.vbproj                                 Sample.NetFrameworkVBNet.ConsoleApp.vbproj  netcoreapp3.1       .NET Core 3.1         .NET Core       vb.net    deprecated     
+/Sample.NetStandard.Class/Sample.NetStandard.Class.csproj                                                       Sample.NetStandard.Class.csproj             netstandard2.0      .NET Standard 2.0     .NET Standard   csharp    supported      
+/Sample.SSDT.Database/Sample.SSDT.Database.sqlproj                                                              Sample.SSDT.Database.sqlproj                v4.7.2              .NET Framework 4.7.2  .NET Framework  csharp    supported      
+/Sample.Unity2020/Assembly-CSharp.csproj                                                                        Assembly-CSharp.csproj                      v4.7.1              .NET Framework 4.7.1  .NET Framework  csharp    supported      
+/Sample.VB6.Calculator/Sample.VB6.WinApp.vbp                                                                    Sample.VB6.WinApp.vbp                       vb6                 Visual Basic 6        Visual Basic 6  vb6       deprecated     
 ";
 
             //Act
@@ -326,16 +346,28 @@ total frameworks,,33,
         if (directory != null || repo != null)
         {
             string expected = @"Path,FileName,FrameworkCode,FrameworkName,Family,Language,Status
+/Sample.Multiple.Directory.Build.Props/src/tools/illink/src/analyzer/analyzer.csproj,analyzer.csproj,net8.0,.NET 8.0,.NET,csharp,in preview
+/Sample.Multiple.Directory.Build.Props/src/tools/illink/src/ILLink.CodeFix/ILLink.CodeFixProvider.csproj,ILLink.CodeFixProvider.csproj,netstandard2.0,.NET Standard 2.0,.NET Standard,csharp,supported
+/Sample.Multiple.Directory.Build.Props/src/tools/illink/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj,ILLink.RoslynAnalyzer.csproj,netstandard2.0,.NET Standard 2.0,.NET Standard,csharp,supported
+/Sample.Multiple.Directory.Build.Props/src/tools/illink/src/ILLink.Tasks/ILLink.Tasks.csproj,ILLink.Tasks.csproj,net472,.NET Framework 4.7.2,.NET Framework,csharp,supported
+/Sample.Multiple.Directory.Build.Props/src/tools/illink/src/ILLink.Tasks/ILLink.Tasks.csproj,ILLink.Tasks.csproj,,(Unknown),(Unknown),csharp,unknown
+/Sample.Multiple.Directory.Build.Props/src/tools/illink/src/ILLink.Tasks/ILLink.Tasks.csproj,ILLink.Tasks.csproj,net8.0,.NET 8.0,.NET,csharp,in preview
+/Sample.Multiple.Directory.Build.Props/src/tools/illink/src/linker/Mono.Linker.csproj,Mono.Linker.csproj,net8.0,.NET 8.0,.NET,csharp,in preview
+/Sample.Multiple.Directory.Build.Props/src/tools/illink/src/tlens/tlens.csproj,tlens.csproj,net8.0,.NET 8.0,.NET,csharp,in preview
 /Sample.MultipleTargets.ConsoleApp/Sample.MultipleTargets.ConsoleApp.csproj,Sample.MultipleTargets.ConsoleApp.csproj,netcoreapp3.1,.NET Core 3.1,.NET Core,csharp,deprecated
+/Sample.MultipleTargets.ConsoleApp/Sample.MultipleTargets.ConsoleApp.csproj,Sample.MultipleTargets.ConsoleApp.csproj,net5.0,.NET 5.0,.NET,csharp,deprecated
 /Sample.MultipleTargets.ConsoleApp/Sample.MultipleTargets.ConsoleApp.csproj,Sample.MultipleTargets.ConsoleApp.csproj,net462,.NET Framework 4.6.2,.NET Framework,csharp,supported
 /Sample.Net5.ConsoleApp/Sample.Net5.ConsoleApp.csproj,Sample.Net5.ConsoleApp.csproj,net5.0,.NET 5.0,.NET,csharp,deprecated
 /Sample.Net6.ConsoleApp/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,supported
 /Sample.Net6.ConsoleApp2/src/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,supported
 /Sample.NET6.Directory.Build.props/App1/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,supported
 /Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj,Calculator.csproj,net6.0-ios,.NET 6.0-ios,.NET,csharp,supported
+/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj,Calculator.csproj,net6.0-maccatalyst,.NET 6.0-maccatalyst,.NET,csharp,supported
 /Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj,Calculator.csproj,net6.0-android,.NET 6.0-android,.NET,csharp,supported
 /Sample.Net6Inception.ConsoleApp/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,supported
-/Sample.Net7.ConsoleApp/Sample.Net7.ConsoleApp.csproj,Sample.Net7.ConsoleApp.csproj,net7.0,.NET 7.0,.NET,csharp,in preview
+/Sample.Net7.ConsoleApp/Sample.Net7.ConsoleApp.csproj,Sample.Net7.ConsoleApp.csproj,net7.0,.NET 7.0,.NET,csharp,supported
+/Sample.Net7.ConsoleApp2/Sample.Net7.ConsoleApp2.csproj,Sample.Net7.ConsoleApp2.csproj,net7.0,.NET 7.0,.NET,csharp,supported
+/Sample.Net8.ConsoleApp/Sample.Net8.ConsoleApp.csproj,Sample.Net8.ConsoleApp.csproj,net8.0,.NET 8.0,.NET,csharp,in preview
 /Sample.NetCore1.0.ConsoleApp/project.json,project.json,netcoreapp1.0,.NET Core 1.0,.NET Core,csharp,deprecated
 /Sample.NetCore1.1.ConsoleApp/project.json,project.json,netcoreapp1.1,.NET Core 1.1,.NET Core,csharp,deprecated
 /Sample.NetCore2.0.ConsoleApp/Sample.NetCore2.0.ConsoleApp.csproj,Sample.NetCore2.0.ConsoleApp.csproj,netcoreapp2.0,.NET Core 2.0,.NET Core,csharp,deprecated
@@ -353,6 +385,7 @@ total frameworks,,33,
 /Sample.NETFramework4.6.1FSharp.HelloWorld/HelloWorld.fsproj,HelloWorld.fsproj,net461,.NET Framework 4.6.1,.NET Framework,fsharp,deprecated
 /Sample.NetFramework40.WebApp/WorldBankSample.csproj,WorldBankSample.csproj,v4.0,.NET Framework 4.0,.NET Framework,csharp,deprecated
 /Sample.NetFramework45.WebApp/WorldBankSample.csproj,WorldBankSample.csproj,v4.5,.NET Framework 4.5,.NET Framework,csharp,deprecated
+/Sample.NetFramework451.WebApp/WorldBankSample.csproj,WorldBankSample.csproj,v4.5.1,.NET Framework 4.5.1,.NET Framework,csharp,deprecated
 /Sample.NetFrameworkInvalid.App/VBProj.vbproj,VBProj.vbproj,,(Unknown),(Unknown),vb.net,unknown
 /Sample.NetFrameworkVBNet.ConsoleApp/Sample.NetFrameworkVBNet.ConsoleApp.vbproj,Sample.NetFrameworkVBNet.ConsoleApp.vbproj,netcoreapp3.1,.NET Core 3.1,.NET Core,vb.net,deprecated
 /Sample.NetStandard.Class/Sample.NetStandard.Class.csproj,Sample.NetStandard.Class.csproj,netstandard2.0,.NET Standard 2.0,.NET Standard,csharp,supported

--- a/src/DotNetCensus.Tests/RepoDataAccessTests.cs
+++ b/src/DotNetCensus.Tests/RepoDataAccessTests.cs
@@ -101,6 +101,7 @@ total frameworks                       50
 .NET Framework 3.5    .NET Framework   2      EOL: 9-Jan-2029
 .NET Framework 4.0    .NET Framework   1      deprecated     
 .NET Framework 4.5    .NET Framework   1      deprecated     
+.NET Framework 4.5.1  .NET Framework   1      deprecated     
 .NET Framework 4.6.1  .NET Framework   1      deprecated     
 .NET Framework 4.6.2  .NET Framework   1      supported      
 .NET Framework 4.7.1  .NET Framework   1      supported      
@@ -108,7 +109,7 @@ total frameworks                       50
 .NET Standard 2.0     .NET Standard    3      supported      
 (Unknown)             (Unknown)        2      unknown        
 Visual Basic 6        Visual Basic 6   1      deprecated     
-total frameworks                       50                    
+total frameworks                       51                    
 ";
 
             //Act

--- a/src/DotNetCensus.Tests/SampleDataUnitTests.cs
+++ b/src/DotNetCensus.Tests/SampleDataUnitTests.cs
@@ -90,7 +90,7 @@ public class SampleDataUnitTests : DirectoryBasedTests
 
         //Asset
         Assert.IsNotNull(results);
-        Assert.AreEqual(28, results.Count);
+        Assert.AreEqual(29, results.Count);
         Assert.AreEqual(2, results[0].Count);
         Assert.AreEqual(".NET 5.0", results[0].Framework);
         Assert.AreEqual(1, results[^1].Count);

--- a/src/DotNetCensus.Tests/SampleDataUnitTests.cs
+++ b/src/DotNetCensus.Tests/SampleDataUnitTests.cs
@@ -90,7 +90,7 @@ public class SampleDataUnitTests : DirectoryBasedTests
 
         //Asset
         Assert.IsNotNull(results);
-        Assert.AreEqual(27, results.Count);
+        Assert.AreEqual(28, results.Count);
         Assert.AreEqual(2, results[0].Count);
         Assert.AreEqual(".NET 5.0", results[0].Framework);
         Assert.AreEqual(1, results[^1].Count);

--- a/src/DotNetCensus.Tests/SampleDataUnitTests.cs
+++ b/src/DotNetCensus.Tests/SampleDataUnitTests.cs
@@ -149,7 +149,7 @@ public class SampleDataUnitTests : DirectoryBasedTests
         Assert.AreEqual("vb.net", results[2].Language);
         Assert.AreEqual(1, results[3].Count);
         Assert.AreEqual("vb6", results[3].Language);
-        Assert.AreEqual(45, results[4].Count);
+        Assert.AreEqual(46, results[4].Count);
         Assert.AreEqual("total languages", results[4].Language);
     }
 

--- a/src/DotNetCensus.Tests/SampleDataUnitTests.cs
+++ b/src/DotNetCensus.Tests/SampleDataUnitTests.cs
@@ -141,7 +141,7 @@ public class SampleDataUnitTests : DirectoryBasedTests
         //Asset
         Assert.IsNotNull(results);
         Assert.AreEqual(5, results.Count);
-        Assert.AreEqual(37, results[0].Count);
+        Assert.AreEqual(38, results[0].Count);
         Assert.AreEqual("csharp", results[0].Language);
         Assert.AreEqual(2, results[1].Count);
         Assert.AreEqual("fsharp", results[1].Language);

--- a/src/DotNetCensus.Tests/SampleDataUnitTests.cs
+++ b/src/DotNetCensus.Tests/SampleDataUnitTests.cs
@@ -114,7 +114,7 @@ public class SampleDataUnitTests : DirectoryBasedTests
         //Asset
         Assert.IsNotNull(results);
         Assert.AreEqual(4, results.Count);
-        Assert.AreEqual(37, results[0].Count);
+        Assert.AreEqual(38, results[0].Count);
         Assert.AreEqual("csharp", results[0].Language);
         Assert.AreEqual(2, results[1].Count);
         Assert.AreEqual("fsharp", results[1].Language);

--- a/src/DotNetCensus.Tests/SampleDataUnitTests.cs
+++ b/src/DotNetCensus.Tests/SampleDataUnitTests.cs
@@ -65,7 +65,7 @@ public class SampleDataUnitTests : DirectoryBasedTests
 
         //Asset
         Assert.IsNotNull(results);
-        Assert.AreEqual(28, results.Count);
+        Assert.AreEqual(29, results.Count);
         Assert.AreEqual(2, results[0].Count);
         Assert.AreEqual(".NET 5.0", results[0].Framework);
         Assert.AreEqual(1, results[^2].Count);
@@ -90,7 +90,7 @@ public class SampleDataUnitTests : DirectoryBasedTests
 
         //Asset
         Assert.IsNotNull(results);
-        Assert.AreEqual(29, results.Count);
+        Assert.AreEqual(28, results.Count);
         Assert.AreEqual(2, results[0].Count);
         Assert.AreEqual(".NET 5.0", results[0].Framework);
         Assert.AreEqual(1, results[^1].Count);

--- a/src/DotNetCensus.Tests/SampleDataUnitTests.cs
+++ b/src/DotNetCensus.Tests/SampleDataUnitTests.cs
@@ -70,7 +70,7 @@ public class SampleDataUnitTests : DirectoryBasedTests
         Assert.AreEqual(".NET 5.0", results[0].Framework);
         Assert.AreEqual(1, results[^2].Count);
         Assert.AreEqual("Visual Basic 6", results[^2].Framework);
-        Assert.AreEqual(45, results[^1].Count);
+        Assert.AreEqual(46, results[^1].Count);
         Assert.AreEqual("total frameworks", results[^1].Framework);
     }
 


### PR DESCRIPTION
Fixing bug where .NET Framework 4.5.1 was shown as unknown instead of unsupported 