### PR TITLE
Second pass on tests after dotnet8 upgrade

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,1 +1,1 @@
-next-version: 1.7.0
+next-version: 1.8.0

--- a/src/DotNetCensus.Tests/ConsoleAppRepoTests.cs
+++ b/src/DotNetCensus.Tests/ConsoleAppRepoTests.cs
@@ -27,8 +27,9 @@ public class ConsoleAppRepoTests : RepoBasedTests
 | .NET 6.0-android     | .NET            | 1     | supported        |
 | .NET 6.0-ios         | .NET            | 1     | supported        |
 | .NET 6.0-maccatalyst | .NET            | 1     | supported        |
-| .NET 7.0             | .NET            | 5     | EOL: 14-May-2024 |
-| .NET 8.0             | .NET            | 7     | supported        |
+| .NET 7.0             | .NET            | 2     | EOL: 14-May-2024 |
+| .NET 8.0             | .NET            | 10    | supported        |
+| .NET 9.0             | .NET            | 1     | in preview       |
 | .NET Core 1.0        | .NET Core       | 1     | deprecated       |
 | .NET Core 1.1        | .NET Core       | 1     | deprecated       |
 | .NET Core 2.0        | .NET Core       | 1     | deprecated       |
@@ -64,7 +65,7 @@ public class ConsoleAppRepoTests : RepoBasedTests
 | .NET Standard 2.1    | .NET Standard   | 1     | supported        |
 | (Unknown)            | (Unknown)       | 2     | unknown          |
 | Visual Basic 6       | Visual Basic 6  | 1     | deprecated       |
-| total frameworks     |                 | 69    |                  |
+| total frameworks     |                 | 70    |                  |
 
 ";
 

--- a/src/DotNetCensus.Tests/ConsoleAppRepoTests.cs
+++ b/src/DotNetCensus.Tests/ConsoleAppRepoTests.cs
@@ -101,8 +101,9 @@ public class ConsoleAppRepoTests : RepoBasedTests
 | .NET 6.0-android     | .NET            | 1     | supported        |
 | .NET 6.0-ios         | .NET            | 1     | supported        |
 | .NET 6.0-maccatalyst | .NET            | 1     | supported        |
-| .NET 7.0             | .NET            | 5     | EOL: 14-May-2024 |
-| .NET 8.0             | .NET            | 7     | supported        |
+| .NET 7.0             | .NET            | 2     | EOL: 14-May-2024 |
+| .NET 8.0             | .NET            | 10    | supported        |
+| .NET 9.0             | .NET            | 1     | in preview       |
 | .NET Core 1.0        | .NET Core       | 1     | deprecated       |
 | .NET Core 1.1        | .NET Core       | 1     | deprecated       |
 | .NET Core 2.0        | .NET Core       | 1     | deprecated       |
@@ -138,7 +139,7 @@ public class ConsoleAppRepoTests : RepoBasedTests
 | .NET Standard 2.1    | .NET Standard   | 1     | supported        |
 | (Unknown)            | (Unknown)       | 2     | unknown          |
 | Visual Basic 6       | Visual Basic 6  | 1     | deprecated       |
-| total frameworks     |                 | 69    |                  |
+| total frameworks     |                 | 70    |                  |
 
 ";
 


### PR DESCRIPTION
This pull request includes updates to the supported frameworks for the `RunConsoleAppWithTotalsFromRepoTest()` and `RunConsoleAppWithTotalsFromBranchAndRepoTest()` methods in `src/DotNetCensus.Tests/ConsoleAppRepoTests.cs`, and updates the version number in `GitVersion.yml` from `1.7.0` to `1.8.0`.

Main changes:

* `src/DotNetCensus.Tests/ConsoleAppRepoTests.cs`: Updated the number of supported frameworks for the `RunConsoleAppWithTotalsFromRepoTest()` and `RunConsoleAppWithTotalsFromBranchAndRepoTest()` methods, with reductions in `.NET 7.0` and increases in `.NET 8.0` and a new `.NET 9.0` framework added in preview. (Fb24e913)
* <a href="diffhunk://#diff-1b800222c322c27580a65856212fc4fd9bf1128603cb0864b2e85f6f22b567c9L1-R1">`GitVersion.yml`</a>: Updated the version number from `1.7.0` to `1.8.0`.