### PR TITLE
Updated deprecation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Framework             FrameworkFamily  Count  Status
 .NET 6.0              .NET             3      supported       
 .NET 6.0-android      .NET             1      supported       
 .NET 6.0-ios          .NET             1      supported       
-.NET 7.0              .NET             1      EOL: 14-May-2024       
+.NET 7.0              .NET             1      deprecated             
 .NET 8.0              .NET             1      supported        
 .NET 9.0              .NET             1      in preview      
 .NET Core 1.0         .NET Core        1      deprecated      
@@ -116,7 +116,7 @@ Sample.MultipleTargets.ConsoleApp.csproj    \samples\Sample.MultipleTargets.Cons
 Sample.MultipleTargets.ConsoleApp.csproj    \samples\Sample.MultipleTargets.ConsoleApp\Sample.MultipleTargets.ConsoleApp.csproj      net462          .NET Framework 4.6.2  .NET Framework  csharp    supported
 Sample.Net5.ConsoleApp.csproj               \samples\Sample.Net5.ConsoleApp\Sample.Net5.ConsoleApp.csproj                            net5.0          .NET 5.0              .NET            csharp    deprecated
 Sample.Net6.ConsoleApp.csproj               \samples\Sample.Net6.ConsoleApp\Sample.Net6.ConsoleApp.csproj                            net6.0          .NET 6.0              .NET            csharp    supported
-Sample.Net7.ConsoleApp.csproj               \samples\Sample.Net7.ConsoleApp\Sample.Net7.ConsoleApp.csproj                            net7.0          .NET 7.0              .NET            csharp    EOL: 14-May-2024
+Sample.Net7.ConsoleApp.csproj               \samples\Sample.Net7.ConsoleApp\Sample.Net7.ConsoleApp.csproj                            net7.0          .NET 7.0              .NET            csharp    deprecated
 Sample.Net7.ConsoleApp.csproj               \samples\Sample.Net7.ConsoleApp\Sample.Net7.ConsoleApp.csproj                            net8.0          .NET 8.0              .NET            csharp    supported
 Sample.Net8.ConsoleApp.csproj               \samples\Sample.Net8.ConsoleApp\Sample.Net8.ConsoleApp.csproj                            net9.0          .NET 9.0              .NET            csharp    in preview
 Sample.NetCore.ConsoleApp.csproj            \samples\Sample.NetCore3.1.ConsoleApp\Sample.NetCore.ConsoleApp.csproj                   netcoreapp3.1   .NET Core 3.1         .NET Core       csharp    EOL: 13-Dec-2022

--- a/src/DotNetCensus.Core/Projects/ProjectClassification.cs
+++ b/src/DotNetCensus.Core/Projects/ProjectClassification.cs
@@ -207,7 +207,8 @@ public static class ProjectClassification
             framework.Contains("netcoreapp2") ||
             framework.Contains("netcoreapp3") ||
             framework.Contains("netcoreapp5") || //details about netcoreapp5 are unclear, but this scenario was mentioned as supported here: https://github.com/dotnet/designs/blob/main/accepted/2020/net5/net5.md
-            framework.Contains("net5.0"))
+            framework.Contains("net5.0") ||
+            framework.Contains("net7.0"))
         {
             //Unsupported/End of life/red
             return "deprecated";
@@ -223,11 +224,6 @@ public static class ProjectClassification
         {
             //Supported, but old/orange
             return "EOL: 9-Jan-2029";
-        }
-        else if (framework.Contains("net7.0"))
-        {
-            //Supported, but old/orange
-            return "EOL: 14-May-2024";
         }
         else if (framework.Contains("net6.0") ||
             framework.Contains("net8.0") ||

--- a/src/DotNetCensus.Tests/ConsoleAppDirectoryTests.cs
+++ b/src/DotNetCensus.Tests/ConsoleAppDirectoryTests.cs
@@ -41,8 +41,8 @@ public class ConsoleAppDirectoryTests : DirectoryBasedTests
 /Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj,Calculator.csproj,net6.0-maccatalyst,.NET 6.0-maccatalyst,.NET,csharp,supported
 /Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj,Calculator.csproj,net6.0-android,.NET 6.0-android,.NET,csharp,supported
 /Sample.Net6Inception.ConsoleApp/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,supported
-/Sample.Net7.ConsoleApp/Sample.Net7.ConsoleApp.csproj,Sample.Net7.ConsoleApp.csproj,net7.0,.NET 7.0,.NET,csharp,EOL: 14-May-2024
-/Sample.Net7.ConsoleApp2/Sample.Net7.ConsoleApp2.csproj,Sample.Net7.ConsoleApp2.csproj,net7.0,.NET 7.0,.NET,csharp,EOL: 14-May-2024
+/Sample.Net7.ConsoleApp/Sample.Net7.ConsoleApp.csproj,Sample.Net7.ConsoleApp.csproj,net7.0,.NET 7.0,.NET,csharp,deprecated
+/Sample.Net7.ConsoleApp2/Sample.Net7.ConsoleApp2.csproj,Sample.Net7.ConsoleApp2.csproj,net7.0,.NET 7.0,.NET,csharp,deprecated
 /Sample.Net8.ConsoleApp/Sample.Net8.ConsoleApp.csproj,Sample.Net8.ConsoleApp.csproj,net8.0,.NET 8.0,.NET,csharp,supported
 /Sample.Net9.ConsoleApp/Sample.Net9.ConsoleApp.csproj,Sample.Net9.ConsoleApp.csproj,net9.0,.NET 9.0,.NET,csharp,in preview
 /Sample.NetCore1.0.ConsoleApp/project.json,project.json,netcoreapp1.0,.NET Core 1.0,.NET Core,csharp,deprecated
@@ -117,7 +117,7 @@ public class ConsoleAppDirectoryTests : DirectoryBasedTests
 .NET 6.0-android,.NET,1,supported
 .NET 6.0-ios,.NET,1,supported
 .NET 6.0-maccatalyst,.NET,1,supported
-.NET 7.0,.NET,2,EOL: 14-May-2024
+.NET 7.0,.NET,2,deprecated
 .NET 8.0,.NET,7,supported
 .NET 9.0,.NET,1,in preview
 .NET Core 1.0,.NET Core,1,deprecated

--- a/src/DotNetCensus.Tests/ConsoleAppRepoTests.cs
+++ b/src/DotNetCensus.Tests/ConsoleAppRepoTests.cs
@@ -27,7 +27,7 @@ public class ConsoleAppRepoTests : RepoBasedTests
 | .NET 6.0-android     | .NET            | 1     | supported        |
 | .NET 6.0-ios         | .NET            | 1     | supported        |
 | .NET 6.0-maccatalyst | .NET            | 1     | supported        |
-| .NET 7.0             | .NET            | 2     | EOL: 14-May-2024 |
+| .NET 7.0             | .NET            | 2     | deprecated       |
 | .NET 8.0             | .NET            | 10    | supported        |
 | .NET 9.0             | .NET            | 1     | in preview       |
 | .NET Core 1.0        | .NET Core       | 1     | deprecated       |
@@ -102,7 +102,7 @@ public class ConsoleAppRepoTests : RepoBasedTests
 | .NET 6.0-android     | .NET            | 1     | supported        |
 | .NET 6.0-ios         | .NET            | 1     | supported        |
 | .NET 6.0-maccatalyst | .NET            | 1     | supported        |
-| .NET 7.0             | .NET            | 2     | EOL: 14-May-2024 |
+| .NET 7.0             | .NET            | 2     | deprecated       |
 | .NET 8.0             | .NET            | 10    | supported        |
 | .NET 9.0             | .NET            | 1     | in preview       |
 | .NET Core 1.0        | .NET Core       | 1     | deprecated       |

--- a/src/DotNetCensus.Tests/DirectoryDataAccessTests.cs
+++ b/src/DotNetCensus.Tests/DirectoryDataAccessTests.cs
@@ -44,7 +44,7 @@ public class DirectoryDataAccessTests : DirectoryBasedTests
 | .NET 6.0-android     | .NET            | 1     | supported        |
 | .NET 6.0-ios         | .NET            | 1     | supported        |
 | .NET 6.0-maccatalyst | .NET            | 1     | supported        |
-| .NET 7.0             | .NET            | 2     | EOL: 14-May-2024 |
+| .NET 7.0             | .NET            | 2     | deprecated       |
 | .NET 8.0             | .NET            | 7     | supported        |
 | .NET 9.0             | .NET            | 1     | in preview       |
 | .NET Core 1.0        | .NET Core       | 1     | deprecated       |
@@ -134,7 +134,7 @@ public class DirectoryDataAccessTests : DirectoryBasedTests
 | .NET 6.0-android     | .NET            | 1     | supported        |
 | .NET 6.0-ios         | .NET            | 1     | supported        |
 | .NET 6.0-maccatalyst | .NET            | 1     | supported        |
-| .NET 7.0             | .NET            | 2     | EOL: 14-May-2024 |
+| .NET 7.0             | .NET            | 2     | deprecated       |
 | .NET 8.0             | .NET            | 7     | supported        |
 | .NET 9.0             | .NET            | 1     | in preview       |
 | .NET Core 1.0        | .NET Core       | 1     | deprecated       |
@@ -201,7 +201,7 @@ public class DirectoryDataAccessTests : DirectoryBasedTests
 .NET 6.0-android,.NET,1,supported
 .NET 6.0-ios,.NET,1,supported
 .NET 6.0-maccatalyst,.NET,1,supported
-.NET 7.0,.NET,2,EOL: 14-May-2024
+.NET 7.0,.NET,2,deprecated
 .NET 8.0,.NET,7,supported
 .NET 9.0,.NET,1,in preview
 .NET Core 1.0,.NET Core,1,deprecated
@@ -285,8 +285,8 @@ total frameworks,,65,
 | /Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                                                  | Calculator.csproj                                            | net6.0-maccatalyst | .NET 6.0-maccatalyst | .NET           | csharp   | supported        |
 | /Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                                                  | Calculator.csproj                                            | net6.0-android     | .NET 6.0-android     | .NET           | csharp   | supported        |
 | /Sample.Net6Inception.ConsoleApp/Sample.Net6.ConsoleApp.csproj                                                 | Sample.Net6.ConsoleApp.csproj                                | net6.0             | .NET 6.0             | .NET           | csharp   | supported        |
-| /Sample.Net7.ConsoleApp/Sample.Net7.ConsoleApp.csproj                                                          | Sample.Net7.ConsoleApp.csproj                                | net7.0             | .NET 7.0             | .NET           | csharp   | EOL: 14-May-2024 |
-| /Sample.Net7.ConsoleApp2/Sample.Net7.ConsoleApp2.csproj                                                        | Sample.Net7.ConsoleApp2.csproj                               | net7.0             | .NET 7.0             | .NET           | csharp   | EOL: 14-May-2024 |
+| /Sample.Net7.ConsoleApp/Sample.Net7.ConsoleApp.csproj                                                          | Sample.Net7.ConsoleApp.csproj                                | net7.0             | .NET 7.0             | .NET           | csharp   | deprecated       |
+| /Sample.Net7.ConsoleApp2/Sample.Net7.ConsoleApp2.csproj                                                        | Sample.Net7.ConsoleApp2.csproj                               | net7.0             | .NET 7.0             | .NET           | csharp   | deprecated       |
 | /Sample.Net8.ConsoleApp/Sample.Net8.ConsoleApp.csproj                                                          | Sample.Net8.ConsoleApp.csproj                                | net8.0             | .NET 8.0             | .NET           | csharp   | supported        |
 | /Sample.Net9.ConsoleApp/Sample.Net9.ConsoleApp.csproj                                                          | Sample.Net9.ConsoleApp.csproj                                | net9.0             | .NET 9.0             | .NET           | csharp   | in preview       |
 | /Sample.NetCore1.0.ConsoleApp/project.json                                                                     | project.json                                                 | netcoreapp1.0      | .NET Core 1.0        | .NET Core      | csharp   | deprecated       |
@@ -432,8 +432,8 @@ total frameworks,,65,
 /Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj,Calculator.csproj,net6.0-maccatalyst,.NET 6.0-maccatalyst,.NET,csharp,supported
 /Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj,Calculator.csproj,net6.0-android,.NET 6.0-android,.NET,csharp,supported
 /Sample.Net6Inception.ConsoleApp/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,supported
-/Sample.Net7.ConsoleApp/Sample.Net7.ConsoleApp.csproj,Sample.Net7.ConsoleApp.csproj,net7.0,.NET 7.0,.NET,csharp,EOL: 14-May-2024
-/Sample.Net7.ConsoleApp2/Sample.Net7.ConsoleApp2.csproj,Sample.Net7.ConsoleApp2.csproj,net7.0,.NET 7.0,.NET,csharp,EOL: 14-May-2024
+/Sample.Net7.ConsoleApp/Sample.Net7.ConsoleApp.csproj,Sample.Net7.ConsoleApp.csproj,net7.0,.NET 7.0,.NET,csharp,deprecated
+/Sample.Net7.ConsoleApp2/Sample.Net7.ConsoleApp2.csproj,Sample.Net7.ConsoleApp2.csproj,net7.0,.NET 7.0,.NET,csharp,deprecated
 /Sample.Net8.ConsoleApp/Sample.Net8.ConsoleApp.csproj,Sample.Net8.ConsoleApp.csproj,net8.0,.NET 8.0,.NET,csharp,supported
 /Sample.Net9.ConsoleApp/Sample.Net9.ConsoleApp.csproj,Sample.Net9.ConsoleApp.csproj,net9.0,.NET 9.0,.NET,csharp,in preview
 /Sample.NetCore1.0.ConsoleApp/project.json,project.json,netcoreapp1.0,.NET Core 1.0,.NET Core,csharp,deprecated

--- a/src/DotNetCensus.Tests/RepoDataAccessTests.cs
+++ b/src/DotNetCensus.Tests/RepoDataAccessTests.cs
@@ -30,7 +30,7 @@ public class RepoDataAccessTests : RepoBasedTests
 | .NET 6.0-android     | .NET            | 1     | supported        |
 | .NET 6.0-ios         | .NET            | 1     | supported        |
 | .NET 6.0-maccatalyst | .NET            | 1     | supported        |
-| .NET 7.0             | .NET            | 2     | EOL: 14-May-2024 |
+| .NET 7.0             | .NET            | 2     | deprecated       |
 | .NET 8.0             | .NET            | 10    | supported        |
 | .NET 9.0             | .NET            | 1     | in preview       |
 | .NET Core 1.0        | .NET Core       | 1     | deprecated       |
@@ -133,7 +133,7 @@ public class RepoDataAccessTests : RepoBasedTests
 | .NET 6.0-android     | .NET            | 1     | supported        |
 | .NET 6.0-ios         | .NET            | 1     | supported        |
 | .NET 6.0-maccatalyst | .NET            | 1     | supported        |
-| .NET 7.0             | .NET            | 2     | EOL: 14-May-2024 |
+| .NET 7.0             | .NET            | 2     | deprecated       |
 | .NET 8.0             | .NET            | 10    | supported        |
 | .NET 9.0             | .NET            | 1     | in preview       |
 | .NET Core 1.0        | .NET Core       | 1     | deprecated       |
@@ -221,8 +221,8 @@ public class RepoDataAccessTests : RepoBasedTests
 | /samples/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                                                  | Calculator.csproj                                            | net6.0-maccatalyst | .NET 6.0-maccatalyst | .NET           | csharp   | supported        |
 | /samples/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                                                  | Calculator.csproj                                            | net6.0-android     | .NET 6.0-android     | .NET           | csharp   | supported        |
 | /samples/Sample.Net6Inception.ConsoleApp/Sample.Net6.ConsoleApp.csproj                                                 | Sample.Net6.ConsoleApp.csproj                                | net6.0             | .NET 6.0             | .NET           | csharp   | supported        |
-| /samples/Sample.Net7.ConsoleApp/Sample.Net7.ConsoleApp.csproj                                                          | Sample.Net7.ConsoleApp.csproj                                | net7.0             | .NET 7.0             | .NET           | csharp   | EOL: 14-May-2024 |
-| /samples/Sample.Net7.ConsoleApp2/Sample.Net7.ConsoleApp2.csproj                                                        | Sample.Net7.ConsoleApp2.csproj                               | net7.0             | .NET 7.0             | .NET           | csharp   | EOL: 14-May-2024 |
+| /samples/Sample.Net7.ConsoleApp/Sample.Net7.ConsoleApp.csproj                                                          | Sample.Net7.ConsoleApp.csproj                                | net7.0             | .NET 7.0             | .NET           | csharp   | deprecated       |
+| /samples/Sample.Net7.ConsoleApp2/Sample.Net7.ConsoleApp2.csproj                                                        | Sample.Net7.ConsoleApp2.csproj                               | net7.0             | .NET 7.0             | .NET           | csharp   | deprecated       |
 | /samples/Sample.Net8.ConsoleApp/Sample.Net8.ConsoleApp.csproj                                                          | Sample.Net8.ConsoleApp.csproj                                | net8.0             | .NET 8.0             | .NET           | csharp   | supported        |
 | /samples/Sample.Net9.ConsoleApp/Sample.Net9.ConsoleApp.csproj                                                          | Sample.Net9.ConsoleApp.csproj                                | net9.0             | .NET 9.0             | .NET           | csharp   | in preview       |
 | /samples/Sample.NetCore1.0.ConsoleApp/project.json                                                                     | project.json                                                 | netcoreapp1.0      | .NET Core 1.0        | .NET Core      | csharp   | deprecated       |


### PR DESCRIPTION
This pull request primarily deals with the change in status of the .NET 7.0 framework from "EOL: 14-May-2024" to "deprecated". This change is reflected across several files and tests in the codebase. 