### PR TITLE
Update to support .NET 9

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,12 +19,12 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup GitVersion
-      uses: gittools/actions/gitversion/setup@v1.2.0
+      uses: gittools/actions/gitversion/setup@v3.0.0
       with:
         versionSpec: 5.x
     - name: Determine Version
       id: gitversion
-      uses: gittools/actions/gitversion/execute@v1.2.0
+      uses: gittools/actions/gitversion/execute@v3.0.0
     - name: Display GitVersion outputs
       run: |
         echo "Version: ${{ steps.gitversion.outputs.SemVer }}"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Variable Substitution appsettings file for tests
       uses: microsoft/variable-substitution@v1
       with:
@@ -72,7 +72,7 @@ jobs:
         uses: samsmithnz/SamsDotNetSonarCloudAction@v2.1
         with:
           projects: 'src/DotNetCensus/DotNetCensus.csproj,src/DotNetCensus.Core/DotNetCensus.Core.csproj,src/DotNetCensus.Tests/DotNetCensus.Tests.csproj'
-          dotnet-version: '8.0.x'
+          dotnet-version: '9.0.x'
           sonarcloud-organization: 'samsmithnz-github'
           sonarcloud-project: 'samsmithnz_DotNetCensus'
           SONAR_TOKEN: '${{ secrets.SONAR_TOKEN }}'

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,1 +1,1 @@
-next-version: 1.8.0
+next-version: 1.9.0

--- a/samples/Sample.Net10.ConsoleApp/Program.cs
+++ b/samples/Sample.Net10.ConsoleApp/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Sample.Net5.ConsoleApp
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/samples/Sample.Net10.ConsoleApp/Sample.Net10.ConsoleApp.csproj
+++ b/samples/Sample.Net10.ConsoleApp/Sample.Net10.ConsoleApp.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/DotNetCensus.Core/Projects/ProjectClassification.cs
+++ b/src/DotNetCensus.Core/Projects/ProjectClassification.cs
@@ -208,6 +208,7 @@ public static class ProjectClassification
             framework.Contains("netcoreapp3") ||
             framework.Contains("netcoreapp5") || //details about netcoreapp5 are unclear, but this scenario was mentioned as supported here: https://github.com/dotnet/designs/blob/main/accepted/2020/net5/net5.md
             framework.Contains("net5.0") ||
+            framework.Contains("net6.0") ||
             framework.Contains("net7.0"))
         {
             //Unsupported/End of life/red
@@ -225,8 +226,8 @@ public static class ProjectClassification
             //Supported, but old/orange
             return "EOL: 9-Jan-2029";
         }
-        else if (framework.Contains("net6.0") ||
-            framework.Contains("net8.0") ||
+        else if (framework.Contains("net9.0") || //EOL: May 12, 2026
+            framework.Contains("net8.0") || //EOL: November 10, 2026
             framework.Contains("netstandard") ||
             framework.Contains("net47") ||
             framework.Contains("v4.7") ||
@@ -236,7 +237,7 @@ public static class ProjectClassification
             //Supported/Ok/blue
             return "supported";
         }
-        else if (framework.Contains("net9.0"))
+        else if (framework.Contains("net10.0"))
         {
             return "in preview";
         }

--- a/src/DotNetCensus.Tests/ConsoleAppDirectoryTests.cs
+++ b/src/DotNetCensus.Tests/ConsoleAppDirectoryTests.cs
@@ -33,18 +33,19 @@ public class ConsoleAppDirectoryTests : DirectoryBasedTests
 /Sample.MultipleTargets.ConsoleApp/Sample.MultipleTargets.ConsoleApp.csproj,Sample.MultipleTargets.ConsoleApp.csproj,netcoreapp3.1,.NET Core 3.1,.NET Core,csharp,deprecated
 /Sample.MultipleTargets.ConsoleApp/Sample.MultipleTargets.ConsoleApp.csproj,Sample.MultipleTargets.ConsoleApp.csproj,net5.0,.NET 5.0,.NET,csharp,deprecated
 /Sample.MultipleTargets.ConsoleApp/Sample.MultipleTargets.ConsoleApp.csproj,Sample.MultipleTargets.ConsoleApp.csproj,net462,.NET Framework 4.6.2,.NET Framework,csharp,EOL: 12-Jan-2027
+/Sample.Net10.ConsoleApp/Sample.Net10.ConsoleApp.csproj,Sample.Net10.ConsoleApp.csproj,net10.0,.NET 10.0,.NET,csharp,in preview
 /Sample.Net5.ConsoleApp/Sample.Net5.ConsoleApp.csproj,Sample.Net5.ConsoleApp.csproj,net5.0,.NET 5.0,.NET,csharp,deprecated
-/Sample.Net6.ConsoleApp/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,supported
-/Sample.Net6.ConsoleApp2/src/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,supported
-/Sample.NET6.Directory.Build.props/App1/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,supported
-/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj,Calculator.csproj,net6.0-ios,.NET 6.0-ios,.NET,csharp,supported
-/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj,Calculator.csproj,net6.0-maccatalyst,.NET 6.0-maccatalyst,.NET,csharp,supported
-/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj,Calculator.csproj,net6.0-android,.NET 6.0-android,.NET,csharp,supported
-/Sample.Net6Inception.ConsoleApp/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,supported
+/Sample.Net6.ConsoleApp/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,deprecated
+/Sample.Net6.ConsoleApp2/src/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,deprecated
+/Sample.NET6.Directory.Build.props/App1/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,deprecated
+/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj,Calculator.csproj,net6.0-ios,.NET 6.0-ios,.NET,csharp,deprecated
+/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj,Calculator.csproj,net6.0-maccatalyst,.NET 6.0-maccatalyst,.NET,csharp,deprecated
+/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj,Calculator.csproj,net6.0-android,.NET 6.0-android,.NET,csharp,deprecated
+/Sample.Net6Inception.ConsoleApp/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,deprecated
 /Sample.Net7.ConsoleApp/Sample.Net7.ConsoleApp.csproj,Sample.Net7.ConsoleApp.csproj,net7.0,.NET 7.0,.NET,csharp,deprecated
 /Sample.Net7.ConsoleApp2/Sample.Net7.ConsoleApp2.csproj,Sample.Net7.ConsoleApp2.csproj,net7.0,.NET 7.0,.NET,csharp,deprecated
 /Sample.Net8.ConsoleApp/Sample.Net8.ConsoleApp.csproj,Sample.Net8.ConsoleApp.csproj,net8.0,.NET 8.0,.NET,csharp,supported
-/Sample.Net9.ConsoleApp/Sample.Net9.ConsoleApp.csproj,Sample.Net9.ConsoleApp.csproj,net9.0,.NET 9.0,.NET,csharp,in preview
+/Sample.Net9.ConsoleApp/Sample.Net9.ConsoleApp.csproj,Sample.Net9.ConsoleApp.csproj,net9.0,.NET 9.0,.NET,csharp,supported
 /Sample.NetCore1.0.ConsoleApp/project.json,project.json,netcoreapp1.0,.NET Core 1.0,.NET Core,csharp,deprecated
 /Sample.NetCore1.1.ConsoleApp/project.json,project.json,netcoreapp1.1,.NET Core 1.1,.NET Core,csharp,deprecated
 /Sample.NetCore2.0.ConsoleApp/Sample.NetCore2.0.ConsoleApp.csproj,Sample.NetCore2.0.ConsoleApp.csproj,netcoreapp2.0,.NET Core 2.0,.NET Core,csharp,deprecated

--- a/src/DotNetCensus.Tests/ConsoleAppDirectoryTests.cs
+++ b/src/DotNetCensus.Tests/ConsoleAppDirectoryTests.cs
@@ -113,14 +113,15 @@ public class ConsoleAppDirectoryTests : DirectoryBasedTests
             string[] parameters = new string[] { "-d", SamplesPath, "-t", "-f", file };
             StringWriter sw = new();
             string expected = @"Framework,FrameworkFamily,Count,Status
+.NET 10.0,.NET,1,in preview
 .NET 5.0,.NET,2,deprecated
-.NET 6.0,.NET,4,supported
-.NET 6.0-android,.NET,1,supported
-.NET 6.0-ios,.NET,1,supported
-.NET 6.0-maccatalyst,.NET,1,supported
+.NET 6.0,.NET,4,deprecated
+.NET 6.0-android,.NET,1,deprecated
+.NET 6.0-ios,.NET,1,deprecated
+.NET 6.0-maccatalyst,.NET,1,deprecated
 .NET 7.0,.NET,2,deprecated
 .NET 8.0,.NET,7,supported
-.NET 9.0,.NET,1,in preview
+.NET 9.0,.NET,1,supported
 .NET Core 1.0,.NET Core,1,deprecated
 .NET Core 1.1,.NET Core,1,deprecated
 .NET Core 2.0,.NET Core,1,deprecated
@@ -156,7 +157,7 @@ public class ConsoleAppDirectoryTests : DirectoryBasedTests
 .NET Standard 2.1,.NET Standard,1,supported
 (Unknown),(Unknown),2,unknown
 Visual Basic 6,Visual Basic 6,1,deprecated
-total frameworks,,65,
+total frameworks,,66,
 ";
 
             //Act

--- a/src/DotNetCensus.Tests/ConsoleAppRepoTests.cs
+++ b/src/DotNetCensus.Tests/ConsoleAppRepoTests.cs
@@ -98,13 +98,13 @@ public class ConsoleAppRepoTests : RepoBasedTests
             string expected = @"| Framework            | FrameworkFamily | Count | Status           |
 |----------------------|-----------------|-------|------------------|
 | .NET 5.0             | .NET            | 2     | deprecated       |
-| .NET 6.0             | .NET            | 6     | supported        |
-| .NET 6.0-android     | .NET            | 1     | supported        |
-| .NET 6.0-ios         | .NET            | 1     | supported        |
-| .NET 6.0-maccatalyst | .NET            | 1     | supported        |
+| .NET 6.0             | .NET            | 6     | deprecated       |
+| .NET 6.0-android     | .NET            | 1     | deprecated       |
+| .NET 6.0-ios         | .NET            | 1     | deprecated       |
+| .NET 6.0-maccatalyst | .NET            | 1     | deprecated       |
 | .NET 7.0             | .NET            | 2     | deprecated       |
 | .NET 8.0             | .NET            | 10    | supported        |
-| .NET 9.0             | .NET            | 1     | in preview       |
+| .NET 9.0             | .NET            | 1     | supported        |
 | .NET Core 1.0        | .NET Core       | 1     | deprecated       |
 | .NET Core 1.1        | .NET Core       | 1     | deprecated       |
 | .NET Core 2.0        | .NET Core       | 1     | deprecated       |

--- a/src/DotNetCensus.Tests/ConsoleAppRepoTests.cs
+++ b/src/DotNetCensus.Tests/ConsoleAppRepoTests.cs
@@ -23,13 +23,13 @@ public class ConsoleAppRepoTests : RepoBasedTests
             string expected = @"| Framework            | FrameworkFamily | Count | Status           |
 |----------------------|-----------------|-------|------------------|
 | .NET 5.0             | .NET            | 2     | deprecated       |
-| .NET 6.0             | .NET            | 6     | supported        |
-| .NET 6.0-android     | .NET            | 1     | supported        |
-| .NET 6.0-ios         | .NET            | 1     | supported        |
-| .NET 6.0-maccatalyst | .NET            | 1     | supported        |
+| .NET 6.0             | .NET            | 6     | deprecated       |
+| .NET 6.0-android     | .NET            | 1     | deprecated       |
+| .NET 6.0-ios         | .NET            | 1     | deprecated       |
+| .NET 6.0-maccatalyst | .NET            | 1     | deprecated       |
 | .NET 7.0             | .NET            | 2     | deprecated       |
 | .NET 8.0             | .NET            | 10    | supported        |
-| .NET 9.0             | .NET            | 1     | in preview       |
+| .NET 9.0             | .NET            | 1     | supported        |
 | .NET Core 1.0        | .NET Core       | 1     | deprecated       |
 | .NET Core 1.1        | .NET Core       | 1     | deprecated       |
 | .NET Core 2.0        | .NET Core       | 1     | deprecated       |
@@ -66,7 +66,7 @@ public class ConsoleAppRepoTests : RepoBasedTests
 | (Unknown)            | (Unknown)       | 2     | unknown          |
 | Visual Basic 6       | Visual Basic 6  | 1     | deprecated       |
 | total frameworks     |                 | 70    |                  |
-
+    
 ";
 
             //Act

--- a/src/DotNetCensus.Tests/ConsoleAppRepoTests.cs
+++ b/src/DotNetCensus.Tests/ConsoleAppRepoTests.cs
@@ -66,7 +66,7 @@ public class ConsoleAppRepoTests : RepoBasedTests
 | (Unknown)            | (Unknown)       | 2     | unknown          |
 | Visual Basic 6       | Visual Basic 6  | 1     | deprecated       |
 | total frameworks     |                 | 70    |                  |
-    
+
 ";
 
             //Act

--- a/src/DotNetCensus.Tests/DirectoryDataAccessTests.cs
+++ b/src/DotNetCensus.Tests/DirectoryDataAccessTests.cs
@@ -280,18 +280,19 @@ total frameworks,,66,
 | /Sample.MultipleTargets.ConsoleApp/Sample.MultipleTargets.ConsoleApp.csproj                                    | Sample.MultipleTargets.ConsoleApp.csproj                     | netcoreapp3.1      | .NET Core 3.1        | .NET Core      | csharp   | deprecated       |
 | /Sample.MultipleTargets.ConsoleApp/Sample.MultipleTargets.ConsoleApp.csproj                                    | Sample.MultipleTargets.ConsoleApp.csproj                     | net5.0             | .NET 5.0             | .NET           | csharp   | deprecated       |
 | /Sample.MultipleTargets.ConsoleApp/Sample.MultipleTargets.ConsoleApp.csproj                                    | Sample.MultipleTargets.ConsoleApp.csproj                     | net462             | .NET Framework 4.6.2 | .NET Framework | csharp   | EOL: 12-Jan-2027 |
+| /Sample.Net10.ConsoleApp/Sample.Net10.ConsoleApp.csproj                                                        | Sample.Net10.ConsoleApp.csproj                               | net10.0            | .NET 10.0            | .NET           | csharp   | in preview       |
 | /Sample.Net5.ConsoleApp/Sample.Net5.ConsoleApp.csproj                                                          | Sample.Net5.ConsoleApp.csproj                                | net5.0             | .NET 5.0             | .NET           | csharp   | deprecated       |
-| /Sample.Net6.ConsoleApp/Sample.Net6.ConsoleApp.csproj                                                          | Sample.Net6.ConsoleApp.csproj                                | net6.0             | .NET 6.0             | .NET           | csharp   | supported        |
-| /Sample.Net6.ConsoleApp2/src/Sample.Net6.ConsoleApp.csproj                                                     | Sample.Net6.ConsoleApp.csproj                                | net6.0             | .NET 6.0             | .NET           | csharp   | supported        |
-| /Sample.NET6.Directory.Build.props/App1/Sample.Net6.ConsoleApp.csproj                                          | Sample.Net6.ConsoleApp.csproj                                | net6.0             | .NET 6.0             | .NET           | csharp   | supported        |
-| /Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                                                  | Calculator.csproj                                            | net6.0-ios         | .NET 6.0-ios         | .NET           | csharp   | supported        |
-| /Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                                                  | Calculator.csproj                                            | net6.0-maccatalyst | .NET 6.0-maccatalyst | .NET           | csharp   | supported        |
-| /Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                                                  | Calculator.csproj                                            | net6.0-android     | .NET 6.0-android     | .NET           | csharp   | supported        |
-| /Sample.Net6Inception.ConsoleApp/Sample.Net6.ConsoleApp.csproj                                                 | Sample.Net6.ConsoleApp.csproj                                | net6.0             | .NET 6.0             | .NET           | csharp   | supported        |
+| /Sample.Net6.ConsoleApp/Sample.Net6.ConsoleApp.csproj                                                          | Sample.Net6.ConsoleApp.csproj                                | net6.0             | .NET 6.0             | .NET           | csharp   | deprecated       |
+| /Sample.Net6.ConsoleApp2/src/Sample.Net6.ConsoleApp.csproj                                                     | Sample.Net6.ConsoleApp.csproj                                | net6.0             | .NET 6.0             | .NET           | csharp   | deprecated       |
+| /Sample.NET6.Directory.Build.props/App1/Sample.Net6.ConsoleApp.csproj                                          | Sample.Net6.ConsoleApp.csproj                                | net6.0             | .NET 6.0             | .NET           | csharp   | deprecated       |
+| /Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                                                  | Calculator.csproj                                            | net6.0-ios         | .NET 6.0-ios         | .NET           | csharp   | deprecated       |
+| /Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                                                  | Calculator.csproj                                            | net6.0-maccatalyst | .NET 6.0-maccatalyst | .NET           | csharp   | deprecated       |
+| /Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                                                  | Calculator.csproj                                            | net6.0-android     | .NET 6.0-android     | .NET           | csharp   | deprecated       |
+| /Sample.Net6Inception.ConsoleApp/Sample.Net6.ConsoleApp.csproj                                                 | Sample.Net6.ConsoleApp.csproj                                | net6.0             | .NET 6.0             | .NET           | csharp   | deprecated       |
 | /Sample.Net7.ConsoleApp/Sample.Net7.ConsoleApp.csproj                                                          | Sample.Net7.ConsoleApp.csproj                                | net7.0             | .NET 7.0             | .NET           | csharp   | deprecated       |
 | /Sample.Net7.ConsoleApp2/Sample.Net7.ConsoleApp2.csproj                                                        | Sample.Net7.ConsoleApp2.csproj                               | net7.0             | .NET 7.0             | .NET           | csharp   | deprecated       |
 | /Sample.Net8.ConsoleApp/Sample.Net8.ConsoleApp.csproj                                                          | Sample.Net8.ConsoleApp.csproj                                | net8.0             | .NET 8.0             | .NET           | csharp   | supported        |
-| /Sample.Net9.ConsoleApp/Sample.Net9.ConsoleApp.csproj                                                          | Sample.Net9.ConsoleApp.csproj                                | net9.0             | .NET 9.0             | .NET           | csharp   | in preview       |
+| /Sample.Net9.ConsoleApp/Sample.Net9.ConsoleApp.csproj                                                          | Sample.Net9.ConsoleApp.csproj                                | net9.0             | .NET 9.0             | .NET           | csharp   | supported        |
 | /Sample.NetCore1.0.ConsoleApp/project.json                                                                     | project.json                                                 | netcoreapp1.0      | .NET Core 1.0        | .NET Core      | csharp   | deprecated       |
 | /Sample.NetCore1.1.ConsoleApp/project.json                                                                     | project.json                                                 | netcoreapp1.1      | .NET Core 1.1        | .NET Core      | csharp   | deprecated       |
 | /Sample.NetCore2.0.ConsoleApp/Sample.NetCore2.0.ConsoleApp.csproj                                              | Sample.NetCore2.0.ConsoleApp.csproj                          | netcoreapp2.0      | .NET Core 2.0        | .NET Core      | csharp   | deprecated       |
@@ -427,18 +428,19 @@ total frameworks,,66,
 /Sample.MultipleTargets.ConsoleApp/Sample.MultipleTargets.ConsoleApp.csproj,Sample.MultipleTargets.ConsoleApp.csproj,netcoreapp3.1,.NET Core 3.1,.NET Core,csharp,deprecated
 /Sample.MultipleTargets.ConsoleApp/Sample.MultipleTargets.ConsoleApp.csproj,Sample.MultipleTargets.ConsoleApp.csproj,net5.0,.NET 5.0,.NET,csharp,deprecated
 /Sample.MultipleTargets.ConsoleApp/Sample.MultipleTargets.ConsoleApp.csproj,Sample.MultipleTargets.ConsoleApp.csproj,net462,.NET Framework 4.6.2,.NET Framework,csharp,EOL: 12-Jan-2027
+/Sample.Net10.ConsoleApp/Sample.Net10.ConsoleApp.csproj,Sample.Net10.ConsoleApp.csproj,net10.0,.NET 10.0,.NET,csharp,in preview
 /Sample.Net5.ConsoleApp/Sample.Net5.ConsoleApp.csproj,Sample.Net5.ConsoleApp.csproj,net5.0,.NET 5.0,.NET,csharp,deprecated
-/Sample.Net6.ConsoleApp/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,supported
-/Sample.Net6.ConsoleApp2/src/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,supported
-/Sample.NET6.Directory.Build.props/App1/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,supported
-/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj,Calculator.csproj,net6.0-ios,.NET 6.0-ios,.NET,csharp,supported
-/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj,Calculator.csproj,net6.0-maccatalyst,.NET 6.0-maccatalyst,.NET,csharp,supported
-/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj,Calculator.csproj,net6.0-android,.NET 6.0-android,.NET,csharp,supported
-/Sample.Net6Inception.ConsoleApp/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,supported
+/Sample.Net6.ConsoleApp/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,deprecated
+/Sample.Net6.ConsoleApp2/src/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,deprecated
+/Sample.NET6.Directory.Build.props/App1/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,deprecated
+/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj,Calculator.csproj,net6.0-ios,.NET 6.0-ios,.NET,csharp,deprecated
+/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj,Calculator.csproj,net6.0-maccatalyst,.NET 6.0-maccatalyst,.NET,csharp,deprecated
+/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj,Calculator.csproj,net6.0-android,.NET 6.0-android,.NET,csharp,deprecated
+/Sample.Net6Inception.ConsoleApp/Sample.Net6.ConsoleApp.csproj,Sample.Net6.ConsoleApp.csproj,net6.0,.NET 6.0,.NET,csharp,deprecated
 /Sample.Net7.ConsoleApp/Sample.Net7.ConsoleApp.csproj,Sample.Net7.ConsoleApp.csproj,net7.0,.NET 7.0,.NET,csharp,deprecated
 /Sample.Net7.ConsoleApp2/Sample.Net7.ConsoleApp2.csproj,Sample.Net7.ConsoleApp2.csproj,net7.0,.NET 7.0,.NET,csharp,deprecated
 /Sample.Net8.ConsoleApp/Sample.Net8.ConsoleApp.csproj,Sample.Net8.ConsoleApp.csproj,net8.0,.NET 8.0,.NET,csharp,supported
-/Sample.Net9.ConsoleApp/Sample.Net9.ConsoleApp.csproj,Sample.Net9.ConsoleApp.csproj,net9.0,.NET 9.0,.NET,csharp,in preview
+/Sample.Net9.ConsoleApp/Sample.Net9.ConsoleApp.csproj,Sample.Net9.ConsoleApp.csproj,net9.0,.NET 9.0,.NET,csharp,supported
 /Sample.NetCore1.0.ConsoleApp/project.json,project.json,netcoreapp1.0,.NET Core 1.0,.NET Core,csharp,deprecated
 /Sample.NetCore1.1.ConsoleApp/project.json,project.json,netcoreapp1.1,.NET Core 1.1,.NET Core,csharp,deprecated
 /Sample.NetCore2.0.ConsoleApp/Sample.NetCore2.0.ConsoleApp.csproj,Sample.NetCore2.0.ConsoleApp.csproj,netcoreapp2.0,.NET Core 2.0,.NET Core,csharp,deprecated

--- a/src/DotNetCensus.Tests/DirectoryDataAccessTests.cs
+++ b/src/DotNetCensus.Tests/DirectoryDataAccessTests.cs
@@ -39,14 +39,15 @@ public class DirectoryDataAccessTests : DirectoryBasedTests
         {
             string expected = @"| Framework            | FrameworkFamily | Count | Status           |
 |----------------------|-----------------|-------|------------------|
+| .NET 10.0            | .NET            | 1     | in preview       |
 | .NET 5.0             | .NET            | 2     | deprecated       |
-| .NET 6.0             | .NET            | 4     | supported        |
-| .NET 6.0-android     | .NET            | 1     | supported        |
-| .NET 6.0-ios         | .NET            | 1     | supported        |
-| .NET 6.0-maccatalyst | .NET            | 1     | supported        |
+| .NET 6.0             | .NET            | 4     | deprecated       |
+| .NET 6.0-android     | .NET            | 1     | deprecated       |
+| .NET 6.0-ios         | .NET            | 1     | deprecated       |
+| .NET 6.0-maccatalyst | .NET            | 1     | deprecated       |
 | .NET 7.0             | .NET            | 2     | deprecated       |
 | .NET 8.0             | .NET            | 7     | supported        |
-| .NET 9.0             | .NET            | 1     | in preview       |
+| .NET 9.0             | .NET            | 1     | supported        |
 | .NET Core 1.0        | .NET Core       | 1     | deprecated       |
 | .NET Core 1.1        | .NET Core       | 1     | deprecated       |
 | .NET Core 2.0        | .NET Core       | 1     | deprecated       |
@@ -103,9 +104,9 @@ public class DirectoryDataAccessTests : DirectoryBasedTests
         string? file = null;
         if (directory != null || repo != null)
         {
-            string expected = @"| Framework | FrameworkFamily | Count | Status    |
-|-----------|-----------------|-------|-----------|
-| .NET 6.0  | .NET            | 1     | supported |
+            string expected = @"| Framework | FrameworkFamily | Count | Status     |
+|-----------|-----------------|-------|------------|
+| .NET 6.0  | .NET            | 1     | deprecated |
 ";
 
             //Act
@@ -129,14 +130,15 @@ public class DirectoryDataAccessTests : DirectoryBasedTests
         {
             string expected = @"| Framework            | FrameworkFamily | Count | Status           |
 |----------------------|-----------------|-------|------------------|
+| .NET 10.0            | .NET            | 1     | in preview       |
 | .NET 5.0             | .NET            | 2     | deprecated       |
-| .NET 6.0             | .NET            | 4     | supported        |
-| .NET 6.0-android     | .NET            | 1     | supported        |
-| .NET 6.0-ios         | .NET            | 1     | supported        |
-| .NET 6.0-maccatalyst | .NET            | 1     | supported        |
+| .NET 6.0             | .NET            | 4     | deprecated       |
+| .NET 6.0-android     | .NET            | 1     | deprecated       |
+| .NET 6.0-ios         | .NET            | 1     | deprecated       |
+| .NET 6.0-maccatalyst | .NET            | 1     | deprecated       |
 | .NET 7.0             | .NET            | 2     | deprecated       |
 | .NET 8.0             | .NET            | 7     | supported        |
-| .NET 9.0             | .NET            | 1     | in preview       |
+| .NET 9.0             | .NET            | 1     | supported        |
 | .NET Core 1.0        | .NET Core       | 1     | deprecated       |
 | .NET Core 1.1        | .NET Core       | 1     | deprecated       |
 | .NET Core 2.0        | .NET Core       | 1     | deprecated       |
@@ -172,7 +174,7 @@ public class DirectoryDataAccessTests : DirectoryBasedTests
 | .NET Standard 2.1    | .NET Standard   | 1     | supported        |
 | (Unknown)            | (Unknown)       | 2     | unknown          |
 | Visual Basic 6       | Visual Basic 6  | 1     | deprecated       |
-| total frameworks     |                 | 65    |                  |
+| total frameworks     |                 | 66    |                  |
 ";
 
             //Act
@@ -196,14 +198,15 @@ public class DirectoryDataAccessTests : DirectoryBasedTests
         if (directory != null || repo != null)
         {
             string expected = @"Framework,FrameworkFamily,Count,Status
+.NET 10.0,.NET,1,in preview
 .NET 5.0,.NET,2,deprecated
-.NET 6.0,.NET,4,supported
-.NET 6.0-android,.NET,1,supported
-.NET 6.0-ios,.NET,1,supported
-.NET 6.0-maccatalyst,.NET,1,supported
+.NET 6.0,.NET,4,deprecated
+.NET 6.0-android,.NET,1,deprecated
+.NET 6.0-ios,.NET,1,deprecated
+.NET 6.0-maccatalyst,.NET,1,deprecated
 .NET 7.0,.NET,2,deprecated
 .NET 8.0,.NET,7,supported
-.NET 9.0,.NET,1,in preview
+.NET 9.0,.NET,1,supported
 .NET Core 1.0,.NET Core,1,deprecated
 .NET Core 1.1,.NET Core,1,deprecated
 .NET Core 2.0,.NET Core,1,deprecated
@@ -239,7 +242,7 @@ public class DirectoryDataAccessTests : DirectoryBasedTests
 .NET Standard 2.1,.NET Standard,1,supported
 (Unknown),(Unknown),2,unknown
 Visual Basic 6,Visual Basic 6,1,deprecated
-total frameworks,,65,
+total frameworks,,66,
 ";
 
             //Act

--- a/src/DotNetCensus.Tests/DirectoryDataAccessTests.cs
+++ b/src/DotNetCensus.Tests/DirectoryDataAccessTests.cs
@@ -497,12 +497,12 @@ total frameworks,,65,
         string? file = null;
         if (directory != null || repo != null)
         {
-            string expected = @"| Framework            | FrameworkFamily | Count | Status    |
-|----------------------|-----------------|-------|-----------|
-| .NET 6.0-android     | .NET            | 1     | supported |
-| .NET 6.0-ios         | .NET            | 1     | supported |
-| .NET 6.0-maccatalyst | .NET            | 1     | supported |
-| total frameworks     |                 | 3     |           |
+            string expected = @"| Framework            | FrameworkFamily | Count | Status     |
+|----------------------|-----------------|-------|------------|
+| .NET 6.0-android     | .NET            | 1     | deprecated |
+| .NET 6.0-ios         | .NET            | 1     | deprecated |
+| .NET 6.0-maccatalyst | .NET            | 1     | deprecated |
+| total frameworks     |                 | 3     |            |
 ";
 
             //Act

--- a/src/DotNetCensus.Tests/DotNetCensus.Tests.csproj
+++ b/src/DotNetCensus.Tests/DotNetCensus.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -15,10 +15,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/DotNetCensus.Tests/RepoDataAccessTests.cs
+++ b/src/DotNetCensus.Tests/RepoDataAccessTests.cs
@@ -25,14 +25,15 @@ public class RepoDataAccessTests : RepoBasedTests
         {
             string expected = @"| Framework            | FrameworkFamily | Count | Status           |
 |----------------------|-----------------|-------|------------------|
+| .NET 10.0            | .NET            | 1     | in preview       |
 | .NET 5.0             | .NET            | 2     | deprecated       |
-| .NET 6.0             | .NET            | 6     | supported        |
-| .NET 6.0-android     | .NET            | 1     | supported        |
-| .NET 6.0-ios         | .NET            | 1     | supported        |
-| .NET 6.0-maccatalyst | .NET            | 1     | supported        |
+| .NET 6.0             | .NET            | 6     | deprecated       |
+| .NET 6.0-android     | .NET            | 1     | deprecated       |
+| .NET 6.0-ios         | .NET            | 1     | deprecated       |
+| .NET 6.0-maccatalyst | .NET            | 1     | deprecated       |
 | .NET 7.0             | .NET            | 2     | deprecated       |
-| .NET 8.0             | .NET            | 10    | supported        |
-| .NET 9.0             | .NET            | 1     | in preview       |
+| .NET 8.0             | .NET            | 9     | supported        |
+| .NET 9.0             | .NET            | 2     | supported        |
 | .NET Core 1.0        | .NET Core       | 1     | deprecated       |
 | .NET Core 1.1        | .NET Core       | 1     | deprecated       |
 | .NET Core 2.0        | .NET Core       | 1     | deprecated       |
@@ -68,7 +69,7 @@ public class RepoDataAccessTests : RepoBasedTests
 | .NET Standard 2.1    | .NET Standard   | 1     | supported        |
 | (Unknown)            | (Unknown)       | 2     | unknown          |
 | Visual Basic 6       | Visual Basic 6  | 1     | deprecated       |
-| total frameworks     |                 | 70    |                  |
+| total frameworks     |                 | 71    |                  |
 ";
 
             //Act
@@ -214,18 +215,19 @@ public class RepoDataAccessTests : RepoBasedTests
 | /samples/Sample.MultipleTargets.ConsoleApp/Sample.MultipleTargets.ConsoleApp.csproj                                    | Sample.MultipleTargets.ConsoleApp.csproj                     | netcoreapp3.1      | .NET Core 3.1        | .NET Core      | csharp   | deprecated       |
 | /samples/Sample.MultipleTargets.ConsoleApp/Sample.MultipleTargets.ConsoleApp.csproj                                    | Sample.MultipleTargets.ConsoleApp.csproj                     | net5.0             | .NET 5.0             | .NET           | csharp   | deprecated       |
 | /samples/Sample.MultipleTargets.ConsoleApp/Sample.MultipleTargets.ConsoleApp.csproj                                    | Sample.MultipleTargets.ConsoleApp.csproj                     | net462             | .NET Framework 4.6.2 | .NET Framework | csharp   | EOL: 12-Jan-2027 |
+| /samples/Sample.Net10.ConsoleApp/Sample.Net10.ConsoleApp.csproj                                                        | Sample.Net10.ConsoleApp.csproj                               | net10.0            | .NET 10.0            | .NET           | csharp   | in preview       |
 | /samples/Sample.Net5.ConsoleApp/Sample.Net5.ConsoleApp.csproj                                                          | Sample.Net5.ConsoleApp.csproj                                | net5.0             | .NET 5.0             | .NET           | csharp   | deprecated       |
-| /samples/Sample.Net6.ConsoleApp/Sample.Net6.ConsoleApp.csproj                                                          | Sample.Net6.ConsoleApp.csproj                                | net6.0             | .NET 6.0             | .NET           | csharp   | supported        |
-| /samples/Sample.Net6.ConsoleApp2/src/Sample.Net6.ConsoleApp.csproj                                                     | Sample.Net6.ConsoleApp.csproj                                | net6.0             | .NET 6.0             | .NET           | csharp   | supported        |
-| /samples/Sample.NET6.Directory.Build.props/App1/Sample.Net6.ConsoleApp.csproj                                          | Sample.Net6.ConsoleApp.csproj                                | net6.0             | .NET 6.0             | .NET           | csharp   | supported        |
-| /samples/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                                                  | Calculator.csproj                                            | net6.0-ios         | .NET 6.0-ios         | .NET           | csharp   | supported        |
-| /samples/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                                                  | Calculator.csproj                                            | net6.0-maccatalyst | .NET 6.0-maccatalyst | .NET           | csharp   | supported        |
-| /samples/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                                                  | Calculator.csproj                                            | net6.0-android     | .NET 6.0-android     | .NET           | csharp   | supported        |
-| /samples/Sample.Net6Inception.ConsoleApp/Sample.Net6.ConsoleApp.csproj                                                 | Sample.Net6.ConsoleApp.csproj                                | net6.0             | .NET 6.0             | .NET           | csharp   | supported        |
+| /samples/Sample.Net6.ConsoleApp/Sample.Net6.ConsoleApp.csproj                                                          | Sample.Net6.ConsoleApp.csproj                                | net6.0             | .NET 6.0             | .NET           | csharp   | deprecated       |
+| /samples/Sample.Net6.ConsoleApp2/src/Sample.Net6.ConsoleApp.csproj                                                     | Sample.Net6.ConsoleApp.csproj                                | net6.0             | .NET 6.0             | .NET           | csharp   | deprecated       |
+| /samples/Sample.NET6.Directory.Build.props/App1/Sample.Net6.ConsoleApp.csproj                                          | Sample.Net6.ConsoleApp.csproj                                | net6.0             | .NET 6.0             | .NET           | csharp   | deprecated       |
+| /samples/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                                                  | Calculator.csproj                                            | net6.0-ios         | .NET 6.0-ios         | .NET           | csharp   | deprecated       |
+| /samples/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                                                  | Calculator.csproj                                            | net6.0-maccatalyst | .NET 6.0-maccatalyst | .NET           | csharp   | deprecated       |
+| /samples/Sample.Net6.MAUI.Calculator/src/Calculator/Calculator.csproj                                                  | Calculator.csproj                                            | net6.0-android     | .NET 6.0-android     | .NET           | csharp   | deprecated       |
+| /samples/Sample.Net6Inception.ConsoleApp/Sample.Net6.ConsoleApp.csproj                                                 | Sample.Net6.ConsoleApp.csproj                                | net6.0             | .NET 6.0             | .NET           | csharp   | deprecated       |
 | /samples/Sample.Net7.ConsoleApp/Sample.Net7.ConsoleApp.csproj                                                          | Sample.Net7.ConsoleApp.csproj                                | net7.0             | .NET 7.0             | .NET           | csharp   | deprecated       |
 | /samples/Sample.Net7.ConsoleApp2/Sample.Net7.ConsoleApp2.csproj                                                        | Sample.Net7.ConsoleApp2.csproj                               | net7.0             | .NET 7.0             | .NET           | csharp   | deprecated       |
 | /samples/Sample.Net8.ConsoleApp/Sample.Net8.ConsoleApp.csproj                                                          | Sample.Net8.ConsoleApp.csproj                                | net8.0             | .NET 8.0             | .NET           | csharp   | supported        |
-| /samples/Sample.Net9.ConsoleApp/Sample.Net9.ConsoleApp.csproj                                                          | Sample.Net9.ConsoleApp.csproj                                | net9.0             | .NET 9.0             | .NET           | csharp   | in preview       |
+| /samples/Sample.Net9.ConsoleApp/Sample.Net9.ConsoleApp.csproj                                                          | Sample.Net9.ConsoleApp.csproj                                | net9.0             | .NET 9.0             | .NET           | csharp   | supported        |
 | /samples/Sample.NetCore1.0.ConsoleApp/project.json                                                                     | project.json                                                 | netcoreapp1.0      | .NET Core 1.0        | .NET Core      | csharp   | deprecated       |
 | /samples/Sample.NetCore1.1.ConsoleApp/project.json                                                                     | project.json                                                 | netcoreapp1.1      | .NET Core 1.1        | .NET Core      | csharp   | deprecated       |
 | /samples/Sample.NetCore2.0.ConsoleApp/Sample.NetCore2.0.ConsoleApp.csproj                                              | Sample.NetCore2.0.ConsoleApp.csproj                          | netcoreapp2.0      | .NET Core 2.0        | .NET Core      | csharp   | deprecated       |
@@ -266,10 +268,10 @@ public class RepoDataAccessTests : RepoBasedTests
 | /samples/Sample.Unity2020/Assembly-CSharp.csproj                                                                       | Assembly-CSharp.csproj                                       | v4.7.1             | .NET Framework 4.7.1 | .NET Framework | csharp   | supported        |
 | /samples/Sample.VB6.Calculator/Sample.VB6.WinApp.vbp                                                                   | Sample.VB6.WinApp.vbp                                        | vb6                | Visual Basic 6       | Visual Basic 6 | vb6      | deprecated       |
 | /src/DotNetCensus.Core/DotNetCensus.Core.csproj                                                                        | DotNetCensus.Core.csproj                                     | net8.0             | .NET 8.0             | .NET           | csharp   | supported        |
-| /src/DotNetCensus.Core/DotNetCensus.Core.csproj                                                                        | DotNetCensus.Core.csproj                                     | net6.0             | .NET 6.0             | .NET           | csharp   | supported        |
-| /src/DotNetCensus.Tests/DotNetCensus.Tests.csproj                                                                      | DotNetCensus.Tests.csproj                                    | net8.0             | .NET 8.0             | .NET           | csharp   | supported        |
+| /src/DotNetCensus.Core/DotNetCensus.Core.csproj                                                                        | DotNetCensus.Core.csproj                                     | net6.0             | .NET 6.0             | .NET           | csharp   | deprecated       |
+| /src/DotNetCensus.Tests/DotNetCensus.Tests.csproj                                                                      | DotNetCensus.Tests.csproj                                    | net9.0             | .NET 9.0             | .NET           | csharp   | supported        |
 | /src/DotNetCensus/DotNetCensus.csproj                                                                                  | DotNetCensus.csproj                                          | net8.0             | .NET 8.0             | .NET           | csharp   | supported        |
-| /src/DotNetCensus/DotNetCensus.csproj                                                                                  | DotNetCensus.csproj                                          | net6.0             | .NET 6.0             | .NET           | csharp   | supported        |
+| /src/DotNetCensus/DotNetCensus.csproj                                                                                  | DotNetCensus.csproj                                          | net6.0             | .NET 6.0             | .NET           | csharp   | deprecated       |
 ";
 
             //Act

--- a/src/DotNetCensus.Tests/RepoDataAccessTests.cs
+++ b/src/DotNetCensus.Tests/RepoDataAccessTests.cs
@@ -128,14 +128,15 @@ public class RepoDataAccessTests : RepoBasedTests
         {
             string expected = @"| Framework            | FrameworkFamily | Count | Status           |
 |----------------------|-----------------|-------|------------------|
+| .NET 10.0            | .NET            | 1     | in preview       |
 | .NET 5.0             | .NET            | 2     | deprecated       |
-| .NET 6.0             | .NET            | 6     | supported        |
-| .NET 6.0-android     | .NET            | 1     | supported        |
-| .NET 6.0-ios         | .NET            | 1     | supported        |
-| .NET 6.0-maccatalyst | .NET            | 1     | supported        |
+| .NET 6.0             | .NET            | 6     | deprecated       |
+| .NET 6.0-android     | .NET            | 1     | deprecated       |
+| .NET 6.0-ios         | .NET            | 1     | deprecated       |
+| .NET 6.0-maccatalyst | .NET            | 1     | deprecated       |
 | .NET 7.0             | .NET            | 2     | deprecated       |
-| .NET 8.0             | .NET            | 10    | supported        |
-| .NET 9.0             | .NET            | 1     | in preview       |
+| .NET 8.0             | .NET            | 9     | supported        |
+| .NET 9.0             | .NET            | 2     | supported        |
 | .NET Core 1.0        | .NET Core       | 1     | deprecated       |
 | .NET Core 1.1        | .NET Core       | 1     | deprecated       |
 | .NET Core 2.0        | .NET Core       | 1     | deprecated       |
@@ -171,7 +172,7 @@ public class RepoDataAccessTests : RepoBasedTests
 | .NET Standard 2.1    | .NET Standard   | 1     | supported        |
 | (Unknown)            | (Unknown)       | 2     | unknown          |
 | Visual Basic 6       | Visual Basic 6  | 1     | deprecated       |
-| total frameworks     |                 | 70    |                  |
+| total frameworks     |                 | 71    |                  |
 ";
 
             //Act

--- a/src/DotNetCensus.Tests/SampleDataUnitTests.cs
+++ b/src/DotNetCensus.Tests/SampleDataUnitTests.cs
@@ -66,11 +66,11 @@ public class SampleDataUnitTests : DirectoryBasedTests
         //Asset
         Assert.IsNotNull(results);
         Assert.AreEqual(45, results.Count);
-        Assert.AreEqual(2, results[0].Count);
-        Assert.AreEqual(".NET 5.0", results[0].Framework);
+        Assert.AreEqual(1, results[0].Count);
+        Assert.AreEqual(".NET 10.0", results[0].Framework);
         Assert.AreEqual(1, results[^2].Count);
         Assert.AreEqual("Visual Basic 6", results[^2].Framework);
-        Assert.AreEqual(65, results[^1].Count);
+        Assert.AreEqual(66, results[^1].Count);
         Assert.AreEqual("total frameworks", results[^1].Framework);
     }
 
@@ -91,8 +91,8 @@ public class SampleDataUnitTests : DirectoryBasedTests
         //Asset
         Assert.IsNotNull(results);
         Assert.AreEqual(44, results.Count);
-        Assert.AreEqual(2, results[0].Count);
-        Assert.AreEqual(".NET 5.0", results[0].Framework);
+        Assert.AreEqual(1, results[0].Count);
+        Assert.AreEqual(".NET 10.0", results[0].Framework);
         Assert.AreEqual(1, results[^1].Count);
         Assert.AreEqual("Visual Basic 6", results[^1].Framework);
     }
@@ -149,7 +149,7 @@ public class SampleDataUnitTests : DirectoryBasedTests
         Assert.AreEqual("vb.net", results[2].Language);
         Assert.AreEqual(1, results[3].Count);
         Assert.AreEqual("vb6", results[3].Language);
-        Assert.AreEqual(65, results[4].Count);
+        Assert.AreEqual(66, results[4].Count);
         Assert.AreEqual("total languages", results[4].Language);
     }
 

--- a/src/DotNetCensus.Tests/SampleDataUnitTests.cs
+++ b/src/DotNetCensus.Tests/SampleDataUnitTests.cs
@@ -65,7 +65,7 @@ public class SampleDataUnitTests : DirectoryBasedTests
 
         //Asset
         Assert.IsNotNull(results);
-        Assert.AreEqual(44, results.Count);
+        Assert.AreEqual(45, results.Count);
         Assert.AreEqual(2, results[0].Count);
         Assert.AreEqual(".NET 5.0", results[0].Framework);
         Assert.AreEqual(1, results[^2].Count);
@@ -90,7 +90,7 @@ public class SampleDataUnitTests : DirectoryBasedTests
 
         //Asset
         Assert.IsNotNull(results);
-        Assert.AreEqual(43, results.Count);
+        Assert.AreEqual(44, results.Count);
         Assert.AreEqual(2, results[0].Count);
         Assert.AreEqual(".NET 5.0", results[0].Framework);
         Assert.AreEqual(1, results[^1].Count);
@@ -114,7 +114,7 @@ public class SampleDataUnitTests : DirectoryBasedTests
         //Asset
         Assert.IsNotNull(results);
         Assert.AreEqual(4, results.Count);
-        Assert.AreEqual(56, results[0].Count);
+        Assert.AreEqual(57, results[0].Count);
         Assert.AreEqual("csharp", results[0].Language);
         Assert.AreEqual(3, results[1].Count);
         Assert.AreEqual("fsharp", results[1].Language);
@@ -141,7 +141,7 @@ public class SampleDataUnitTests : DirectoryBasedTests
         //Asset
         Assert.IsNotNull(results);
         Assert.AreEqual(5, results.Count);
-        Assert.AreEqual(56, results[0].Count);
+        Assert.AreEqual(57, results[0].Count);
         Assert.AreEqual("csharp", results[0].Language);
         Assert.AreEqual(3, results[1].Count);
         Assert.AreEqual("fsharp", results[1].Language);

--- a/src/DotNetCensus/DotNetCensus.csproj
+++ b/src/DotNetCensus/DotNetCensus.csproj
@@ -20,7 +20,7 @@
 	<ItemGroup>
 		<PackageReference Include="CommandLineParser" Version="2.9.1" />
 		<PackageReference Include="Spectre.Console" Version="0.49.1" />
-		<PackageReference Include="System.Text.Json" Version="8.0.5" />
+		<PackageReference Include="System.Text.Json" Version="9.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This pull request includes several updates to support new .NET versions and adjust the status of existing versions. The most important changes include adding support for .NET 10.0, updating the status of .NET 6.0 to deprecated, and updating GitVersion actions.