### PR TITLE
Update test case for .NET framework status counts

### DIFF
--- a/src/DotNetCensus.Tests/ConsoleAppRepoTests.cs
+++ b/src/DotNetCensus.Tests/ConsoleAppRepoTests.cs
@@ -22,14 +22,15 @@ public class ConsoleAppRepoTests : RepoBasedTests
             StringWriter sw = new();
             string expected = @"| Framework            | FrameworkFamily | Count | Status           |
 |----------------------|-----------------|-------|------------------|
+| .NET 10.0            | .NET            | 1     | in preview       |
 | .NET 5.0             | .NET            | 2     | deprecated       |
 | .NET 6.0             | .NET            | 6     | deprecated       |
 | .NET 6.0-android     | .NET            | 1     | deprecated       |
 | .NET 6.0-ios         | .NET            | 1     | deprecated       |
 | .NET 6.0-maccatalyst | .NET            | 1     | deprecated       |
 | .NET 7.0             | .NET            | 2     | deprecated       |
-| .NET 8.0             | .NET            | 10    | supported        |
-| .NET 9.0             | .NET            | 1     | supported        |
+| .NET 8.0             | .NET            | 9     | supported        |
+| .NET 9.0             | .NET            | 2     | supported        |
 | .NET Core 1.0        | .NET Core       | 1     | deprecated       |
 | .NET Core 1.1        | .NET Core       | 1     | deprecated       |
 | .NET Core 2.0        | .NET Core       | 1     | deprecated       |
@@ -65,7 +66,7 @@ public class ConsoleAppRepoTests : RepoBasedTests
 | .NET Standard 2.1    | .NET Standard   | 1     | supported        |
 | (Unknown)            | (Unknown)       | 2     | unknown          |
 | Visual Basic 6       | Visual Basic 6  | 1     | deprecated       |
-| total frameworks     |                 | 70    |                  |
+| total frameworks     |                 | 71    |                  |
 
 ";
 
@@ -97,14 +98,15 @@ public class ConsoleAppRepoTests : RepoBasedTests
             StringWriter sw = new();
             string expected = @"| Framework            | FrameworkFamily | Count | Status           |
 |----------------------|-----------------|-------|------------------|
+| .NET 10.0            | .NET            | 1     | in preview       |
 | .NET 5.0             | .NET            | 2     | deprecated       |
 | .NET 6.0             | .NET            | 6     | deprecated       |
 | .NET 6.0-android     | .NET            | 1     | deprecated       |
 | .NET 6.0-ios         | .NET            | 1     | deprecated       |
 | .NET 6.0-maccatalyst | .NET            | 1     | deprecated       |
 | .NET 7.0             | .NET            | 2     | deprecated       |
-| .NET 8.0             | .NET            | 10    | supported        |
-| .NET 9.0             | .NET            | 1     | supported        |
+| .NET 8.0             | .NET            | 9     | supported        |
+| .NET 9.0             | .NET            | 2     | supported        |
 | .NET Core 1.0        | .NET Core       | 1     | deprecated       |
 | .NET Core 1.1        | .NET Core       | 1     | deprecated       |
 | .NET Core 2.0        | .NET Core       | 1     | deprecated       |
@@ -140,7 +142,7 @@ public class ConsoleAppRepoTests : RepoBasedTests
 | .NET Standard 2.1    | .NET Standard   | 1     | supported        |
 | (Unknown)            | (Unknown)       | 2     | unknown          |
 | Visual Basic 6       | Visual Basic 6  | 1     | deprecated       |
-| total frameworks     |                 | 70    |                  |
+| total frameworks     |                 | 71    |                  |
 
 ";
 


### PR DESCRIPTION
Updated expected output in `ConsoleAppRepoTests.cs`:
- Changed `.NET 8.0` count from 10 to 9.
- Changed `.NET 9.0` count from 1 to 2.
- Added `.NET 10.0` with count 1 and status in preview.
- Updated total framework count from 70 to 71.